### PR TITLE
Add CODE_OF_CONDUCT and CONTRIBUTING docs, link from README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,15 @@
+# Code of Conduct
+
+## Quick Summary
+
+I'm an amateur developer maintaining this project in my spare time. I appreciate any contributions and try to stay responsive, but please bear with me.
+
+## Guidelines
+
+Just use common sense.
+
+## Contact
+
+If you have concerns about behavior in this project, reach out to me via [email](mailto:maxjiang216@gmail.com).
+
+I'll do my best to address issues promptly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+Thanks for your interest in this project! This is a side project, so contributions are welcome but not expected.
+
+## Getting Started
+
+See the [README](README.md) for installation and usage instructions.
+
+## Questions or Ideas?
+
+Since this is a small solo project, just [email me](mailto:maxjiang216@gmail.com) directly or open an issue. I'm happy to discuss ideas or answer questions.
+
+## Code of Conduct
+
+Please note that this project follows our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ MIT License
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome! Feel free to contribute however you like—see [CONTRIBUTING.md](CONTRIBUTING.md) for more details. Reach out to me via [email](mailto:maxjiang216@gmail.com) if you have any questions.


### PR DESCRIPTION
Add project community and contribution docs.

- **CODE_OF_CONDUCT.md** – Simple code of conduct for an amateur-maintained project, with email contact for issues
- **CONTRIBUTING.md** – Contribution guidelines and contact info, with a link to the Code of Conduct
- **README.md** – Contributing section updated to point to CONTRIBUTING.md and include an email link for questions