### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what's wrong.
+
+**To reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment**
+- OS
+- Python/uv version
+- Any relevant versions

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Problem or motivation**
+What's the use case? Why would this be useful?
+
+**Proposed solution**
+Describe what you have in mind.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+Use common sense. I generate PR descriptions by feeding `git diff --staged` to AI, ideally in the same chat I used for development so it has context beyond the code—motivation, empirical findings for design decisions, etc.


### PR DESCRIPTION
Adds GitHub templates for issues and pull requests:

- **Bug report** – Template for reporting bugs with fields for description, reproduction steps, expected behavior, and environment
- **Feature request** – Template for suggesting features with problem/motivation and proposed solution
- **PR template** – Short note that PR descriptions are generated by feeding `git diff --staged` to AI in the same chat used for development for context beyond the code