### PR TITLE
Simplify PR template and enable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,7 @@
-Use common sense. I generate PR descriptions by feeding `git diff --staged` to AI, ideally in the same chat I used for development so it has context beyond the code—motivation, empirical findings for design decisions, etc.
+## What changed
+(Brief summary if helpful—or just paste your diff below.)
+
+## Why
+(Motivation, context, whatever helps.)
+
+- [ ] Quick sanity check done


### PR DESCRIPTION
**Description:**

## What changed
- Add `config.yml` to enable blank issues in the issue template chooser
- Replace PR template with a minimal layout (What changed / Why / checklist)

## Why
The old PR template was just a note about AI-generated descriptions. A short sectioned template gives a bit of structure but stays light for a solo side project.

- [x] Quick sanity check done