### PR TITLE
Add CI workflow and branch protection docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e .
+
+      - name: Run offline tests
+        run: pytest -m "not online" -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,16 @@ Thanks for your interest in this project! This is a side project, so contributio
 
 See the [README](README.md) for installation and usage instructions.
 
+## Branch Protection
+
+Direct commits to `main`/`master` are disabled. All changes must go through a pull request from a feature branch. Required status checks (CI tests) must pass before merging. To enable this:
+
+1. Go to **Settings → Branches** in your GitHub repo
+2. Add a branch protection rule for `main` (or `master`)
+3. Enable **Require a pull request before merging**
+4. Enable **Require status checks to pass before merging** and add the `test` job
+5. Optionally enable **Do not allow bypassing the above settings**
+
 ## Questions or Ideas?
 
 Since this is a small solo project, just [email me](mailto:maxjiang216@gmail.com) directly or open an issue. I'm happy to discuss ideas or answer questions.


### PR DESCRIPTION
## What changed
- Added `.github/workflows/test.yml` to run offline tests on PRs and pushes to `main`/`master` (Python 3.13, `pytest -m "not online"`).
- Extended `CONTRIBUTING.md` with instructions for setting up branch protection: require PRs, require passing CI, and optionally block bypassing rules.

## Why
- Enforces tests before merge without hitting FIDE live endpoints (more stable and faster CI).
- Keeps main/master protected so changes go through PRs and pass CI before merge.