### PR TITLE
CI: add Black lint check for src/scraper and tests

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,24 @@
+name: Black
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run Black
+        run: black --check src/scraper tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,15 @@ dependencies = [
     "pandas>=2.0.0",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "black>=24.0.0",
+]
+
+[tool.black]
+target-version = ["py313"]
+extend-exclude = "exploratory"
+
 [tool.pytest.ini_options]
 markers = [
     "online: mark test as requiring network (deselect with -m 'not online')",

--- a/src/scraper/get_federations.py
+++ b/src/scraper/get_federations.py
@@ -2,6 +2,7 @@
 """
 Scrape FIDE website to get the list of federations.
 """
+
 import argparse
 import csv
 import time

--- a/src/scraper/get_tournaments.py
+++ b/src/scraper/get_tournaments.py
@@ -5,6 +5,7 @@ Fast FIDE tournament scraper using direct AJAX calls.
 This script fetches tournament lists for all federations using direct HTTP
 requests to the JSON endpoints, which is much faster than using a headless browser.
 """
+
 import argparse
 import asyncio
 import csv


### PR DESCRIPTION
**Description:**

## What changed

- Add a GitHub Actions workflow that runs `black --check` on `src/scraper` and `tests` on every push and PR to `main`/`master`
- Add Black as a dev dependency in `pyproject.toml`, with `[tool.black]` config (target Python 3.13, exclude `exploratory`)
- Format `get_federations.py` and `get_tournaments.py` with Black

## Why

To keep formatting consistent and catch unformatted code in CI. Black is used as the Python formatter for this project.