### PR TITLE
refactor(validate): Infer all paths from run_type and run_name

### DIFF
--- a/handlers/README.md
+++ b/handlers/README.md
@@ -103,17 +103,12 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
 {
   "run_type": "prod",
   "run_name": "2024-01",
-  "bucket": "fide-glicko",
-  "players_uri": null,
-  "details_uri": null,
-  "reports_uri": null
+  "bucket": "fide-glicko"
 }
 ```
 - **run_type**, **run_name**: Required (as above).
 - **bucket**: default fide-glicko
-- **players_uri**: Optional. Defaults to latest in `{bucket}/player_lists/data/`.
-- **details_uri**: Optional. Defaults to `{base}/data/tournament_details.parquet`.
-- **reports_uri**: Optional. Defaults to `{base}/data/tournament_reports_games.parquet`.
+- All paths inferred: details `{base}/data/tournament_details.parquet`, reports `{base}/data/tournament_reports_games.parquet`, players latest in `{bucket}/player_lists/data/`.
 - Inputs: Merged details, reports_games, and latest player list (run merge_chunks first).
 - Output: `{base}/reports/validation_report.json`
 - Returns: `report_uri`, `has_issues`, `player_list_vs_reports`, `details_vs_reports`

--- a/handlers/validate.py
+++ b/handlers/validate.py
@@ -5,18 +5,13 @@ Event shape:
 {
     "run_type": "prod",
     "run_name": "2024-01",
-    "bucket": "fide-glicko",
-    "players_uri": null,
-    "details_uri": null,
-    "reports_uri": null
+    "bucket": "fide-glicko"
 }
 
 - run_type: prod | custom | test (default: custom)
 - run_name: Required for prod/custom. Ignored for test.
 - bucket: S3 bucket (default: fide-glicko)
-- players_uri: Optional. Defaults to latest in player_lists/data/.
-- details_uri: Optional. Defaults to {base}/data/tournament_details.parquet.
-- reports_uri: Optional. Defaults to {base}/data/tournament_reports_games.parquet.
+- All paths inferred from run_type and run_name.
 
 Inputs: {base}/data/tournament_details.parquet, {base}/data/tournament_reports_games.parquet,
         latest player_lists/data/player_list_*.parquet
@@ -38,9 +33,6 @@ def lambda_handler(event: dict, context) -> dict:
     run_type = event.get("run_type", "custom")
     run_name = event.get("run_name")
     bucket = event.get("bucket", "fide-glicko")
-    players_uri = event.get("players_uri")
-    details_uri = event.get("details_uri")
-    reports_uri = event.get("reports_uri")
 
     if run_type not in ("prod", "custom", "test"):
         return {
@@ -67,9 +59,6 @@ def lambda_handler(event: dict, context) -> dict:
             bucket=bucket,
             run_type=run_type,
             run_name=run_name,
-            players_uri=players_uri,
-            details_uri=details_uri,
-            reports_uri=reports_uri,
             quiet=False,
         )
     except RuntimeError as e:

--- a/infra/deploy_validate_lambda.sh
+++ b/infra/deploy_validate_lambda.sh
@@ -102,4 +102,4 @@ else
 fi
 
 echo "Done. Invoke with:"
-echo "  aws lambda invoke --function-name $FUNCTION_NAME --payload '{\"run_type\":\"custom\",\"run_name\":\"2024-01\",\"bucket\":\"fide-glicko\"}' out.json && cat out.json"
+echo "  aws lambda invoke --function-name $FUNCTION_NAME --payload '{\"run_type\":\"test\",\"bucket\":\"fide-glicko\"}' out.json && cat out.json"

--- a/src/scraper/validate_pipeline.py
+++ b/src/scraper/validate_pipeline.py
@@ -216,22 +216,20 @@ def run(
     run_type: str,
     run_name: str | None,
     *,
-    players_uri: str | None = None,
-    details_uri: str | None = None,
-    reports_uri: str | None = None,
     quiet: bool = False,
 ) -> dict:
     """
     Validate pipeline data for a run. Downloads from S3, runs validation, uploads report.
 
+    All paths inferred from run_type and run_name:
+    - details: {base}/data/tournament_details.parquet
+    - reports: {base}/data/tournament_reports_games.parquet
+    - players: latest in {bucket}/player_lists/data/
+
     Args:
         bucket: S3 bucket.
         run_type: prod | custom | test.
         run_name: Required for prod/custom. Ignored for test.
-        federations_uri: Unused (for API consistency).
-        players_uri: Optional. Defaults to latest in player_lists/data/.
-        details_uri: Optional. Defaults to {base}/data/tournament_details.parquet.
-        reports_uri: Optional. Defaults to {base}/data/tournament_reports_games.parquet.
         quiet: Reduce log output.
 
     Returns:
@@ -245,7 +243,6 @@ def run(
         build_s3_uri_for_run,
         download_to_file,
         output_exists,
-        parse_s3_uri,
         resolve_latest_players_list_uri,
         write_output,
     )
@@ -256,16 +253,13 @@ def run(
 
     base = build_run_base(run_type, run_name)
 
-    if details_uri is None:
-        details_uri = build_s3_uri_for_run(
-            bucket, run_type, run_name, "data", "tournament_details.parquet"
-        )
-    if reports_uri is None:
-        reports_uri = build_s3_uri_for_run(
-            bucket, run_type, run_name, "data", "tournament_reports_games.parquet"
-        )
-    if players_uri is None:
-        players_uri = resolve_latest_players_list_uri(bucket)
+    details_uri = build_s3_uri_for_run(
+        bucket, run_type, run_name, "data", "tournament_details.parquet"
+    )
+    reports_uri = build_s3_uri_for_run(
+        bucket, run_type, run_name, "data", "tournament_reports_games.parquet"
+    )
+    players_uri = resolve_latest_players_list_uri(bucket)
 
     if not players_uri:
         raise RuntimeError(


### PR DESCRIPTION
## What changed

- Removed optional `players_uri`, `details_uri`, and `reports_uri` from the validate Lambda event.
- Paths are now inferred from `run_type` and `run_name`: details and reports from `{base}/data/`, players from latest in `{bucket}/player_lists/data/`.
- Aligns with merge_chunks and other Lambdas that infer paths from run parameters.

## Why

- **Consistency**: Other Lambdas (merge_chunks, details_chunk, reports_chunk, etc.) infer paths from `run_type` and `run_name`; validate should do the same.
- **Simpler API**: The event only needs `run_type`, `run_name`, and `bucket`. No optional URI overrides to document or maintain.
- **Fewer edge cases**: Overriding URIs could lead to inconsistent or mismatched paths; inferring them from run params avoids that.