### PR TITLE
refactor(scraper): Fail fast when required input files are missing

### DIFF
--- a/exploratory/validate_pipeline.py
+++ b/exploratory/validate_pipeline.py
@@ -207,6 +207,26 @@ def main() -> int:
         details_path = base / args.data_dir / "tournament_details" / f"{month_key}.parquet"
         reports_path = base / args.data_dir / "tournament_reports" / f"{month_key}_games.parquet"
 
+    # Fail fast if required files are missing
+    if not players_path.exists():
+        logger.error(
+            "Player list not found: %s. Run get_player_list first.",
+            players_path,
+        )
+        sys.exit(1)
+    if not details_path.exists():
+        logger.error(
+            "Tournament details not found: %s. Run get_tournament_details first.",
+            details_path,
+        )
+        sys.exit(1)
+    if not reports_path.exists():
+        logger.error(
+            "Tournament reports not found: %s. Run get_tournament_reports first.",
+            reports_path,
+        )
+        sys.exit(1)
+
     logger.info("Validating year=%s month=%s", args.year, args.month)
 
     has_error = False

--- a/src/scraper/get_tournament_details.py
+++ b/src/scraper/get_tournament_details.py
@@ -1069,6 +1069,15 @@ def main():
         logger.error("Error: specify --input or --year and --month (or --run-type)")
         sys.exit(1)
 
+    from s3_io import output_exists as _path_exists
+
+    if not _path_exists(input_path):
+        logger.error(
+            "Tournament IDs file not found: %s. Run get_tournaments first.",
+            input_path,
+        )
+        sys.exit(1)
+
     # Determine output paths
     parquet_path = None
     json_path = None

--- a/src/scraper/get_tournament_reports.py
+++ b/src/scraper/get_tournament_reports.py
@@ -1643,6 +1643,14 @@ def main():
 
     if args.input:
         input_path = args.input
+        from s3_io import output_exists as _path_exists
+
+        if not _path_exists(input_path):
+            logger.error(
+                "Tournament codes file not found: %s. Run get_tournament_details first.",
+                input_path,
+            )
+            sys.exit(1)
         try:
             tournament_codes = read_tournament_codes(input_path)
         except Exception as e:

--- a/src/scraper/get_tournaments.py
+++ b/src/scraper/get_tournaments.py
@@ -915,6 +915,13 @@ def main() -> int:
         logger.info("Output %s already exists. Use --override to replace.", output_path)
         return 0
 
+    if not federations_path.exists():
+        logger.error(
+            "Federations file not found: %s. Run get_federations first.",
+            federations_path,
+        )
+        return 1
+
     # Run the scraper
     try:
         asyncio.run(

--- a/src/scraper/split_tournament_ids.py
+++ b/src/scraper/split_tournament_ids.py
@@ -3,7 +3,7 @@
 Split tournament IDs into even chunks for fan-out processing.
 
 Reads IDs from a file (S3 or local), splits into N chunks, writes each chunk.
-Can optionally invoke the tournaments Lambda first to produce the IDs file.
+Fails fast if the IDs file does not exist.
 """
 
 import argparse
@@ -121,6 +121,11 @@ def run(
     """
     if quiet:
         logging.getLogger().setLevel(logging.WARNING)
+
+    if not _output_exists(ids_path):
+        raise RuntimeError(
+            f"Tournament IDs file not found: {ids_path}. Run get_tournaments first."
+        )
 
     ids = _read_ids(ids_path)
     if not ids:


### PR DESCRIPTION
## What changed

Added fail-fast checks so all scrapers exit immediately with clear errors when required input files are missing, instead of continuing and failing later (or silently skipping).

- **get_tournaments**: Checks federations file exists before scraping.
- **get_tournament_details**: Checks tournament IDs file exists (local or S3) before processing.
- **get_tournament_reports**: Checks input file exists when using `--input`.
- **split_tournament_ids**: Checks IDs file exists at start of `run()`; raises `RuntimeError` if missing.
- **exploratory/validate_pipeline**: Checks players, details, and reports files exist before validation.

Also updated `split_tournament_ids` docstring (removed outdated "invoke Lambda" note).

## Why

- **Predictable behavior**: Scripts never run other scripts or try to "fix" missing data; they fail as soon as a dependency is missing.
- **Clear errors**: Users get explicit messages (e.g. "Run get_federations first") instead of generic read or parse errors.
- **Pipeline hygiene**: Orchestrators (e.g. `run_full_pipeline`) can rely on explicit failures and correct ordering instead of implicit behavior.