### PR TITLE
fix(ci): Use explicit S3 bucket and ECR repos to bypass managed stack

### DIFF
--- a/infra/github-deploy-policy.json
+++ b/infra/github-deploy-policy.json
@@ -1,0 +1,125 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CloudFormation",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:CreateStack",
+        "cloudformation:UpdateStack",
+        "cloudformation:DeleteStack",
+        "cloudformation:DescribeStacks",
+        "cloudformation:DescribeStackEvents",
+        "cloudformation:DescribeStackResource",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:GetTemplate",
+        "cloudformation:ListStackResources",
+        "cloudformation:ValidateTemplate"
+      ],
+      "Resource": [
+        "arn:aws:cloudformation:us-east-1:710271917035:stack/fide-glicko/*"
+      ]
+    },
+    {
+      "Sid": "CloudFormationChangeSet",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:CreateChangeSet",
+        "cloudformation:DeleteChangeSet",
+        "cloudformation:DescribeChangeSet",
+        "cloudformation:ExecuteChangeSet"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "S3DeployBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::aws-sam-cli-managed-default-samclisourcebucket-*",
+        "arn:aws:s3:::aws-sam-cli-managed-default-samclisourcebucket-*/*"
+      ]
+    },
+    {
+      "Sid": "Lambda",
+      "Effect": "Allow",
+      "Action": [
+        "lambda:CreateFunction",
+        "lambda:DeleteFunction",
+        "lambda:GetFunction",
+        "lambda:GetFunctionConfiguration",
+        "lambda:UpdateFunctionCode",
+        "lambda:UpdateFunctionConfiguration",
+        "lambda:ListVersionsByFunction",
+        "lambda:PublishVersion",
+        "lambda:CreateAlias",
+        "lambda:DeleteAlias",
+        "lambda:UpdateAlias",
+        "lambda:GetAlias",
+        "lambda:AddPermission",
+        "lambda:RemovePermission"
+      ],
+      "Resource": "arn:aws:lambda:us-east-1:710271917035:function:fide-glicko-*"
+    },
+    {
+      "Sid": "IAMRoles",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:GetRole",
+        "iam:PassRole",
+        "iam:AttachRolePolicy",
+        "iam:DetachRolePolicy",
+        "iam:PutRolePolicy",
+        "iam:DeleteRolePolicy",
+        "iam:GetRolePolicy",
+        "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies",
+        "iam:TagRole",
+        "iam:UntagRole"
+      ],
+      "Resource": "arn:aws:iam::710271917035:role/fide-glicko-*"
+    },
+    {
+      "Sid": "ECR",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ECRRepos",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:CreateRepository",
+        "ecr:DescribeRepositories",
+        "ecr:DescribeImages",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage"
+      ],
+      "Resource": "arn:aws:ecr:us-east-1:710271917035:repository/fideglicko*"
+    },
+    {
+      "Sid": "StepFunctions",
+      "Effect": "Allow",
+      "Action": [
+        "states:CreateStateMachine",
+        "states:UpdateStateMachine",
+        "states:DeleteStateMachine",
+        "states:DescribeStateMachine",
+        "states:ListStateMachines"
+      ],
+      "Resource": "arn:aws:states:us-east-1:710271917035:stateMachine:fide-glicko-pipeline"
+    }
+  ]
+}

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,11 +1,22 @@
 # SAM deploy configuration
 # Override with --config-env <env> for multiple environments
+#
+# resolve_s3=false and resolve_image_repos=false bypass the managed stack
+# (aws-sam-cli-managed-default) to avoid "InitialCreation" errors in CI.
 version = 0.1
 
 [default.deploy.parameters]
 stack_name = "fide-glicko"
-resolve_s3 = true
-resolve_image_repos = true
+resolve_s3 = false
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-2kqs2vt0rs5c"
+resolve_image_repos = false
+image_repositories = [
+  "PlayerListFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko327ae736/playerlistfunctionbe35717crepo",
+  "DetailsChunkFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko327ae736/detailschunkfunction7fddf1b8repo",
+  "ReportsChunkFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko327ae736/reportschunkfunctionce85551erepo",
+  "MergeChunksFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko327ae736/mergechunksfunctione49a84d4repo",
+  "ValidateFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko327ae736/validatefunctioneddf4248repo"
+]
 capabilities = "CAPABILITY_IAM"
 parameter_overrides = []
 confirm_changeset = false


### PR DESCRIPTION
## What

Adds an IAM policy for the GitHub deploy role and updates `samconfig.toml` so SAM uses explicit S3 and ECR resources instead of the managed stack.

## Why

The deploy role only had `AmazonS3FullAccess` and `AWSLambda_FullAccess`, which were both too broad and missing CloudFormation permissions for the CompanionStack. SAM deploy also hit "Stack [aws-sam-cli-managed-default] already exists and cannot be created again with the changeSet [InitialCreation]" in CI when `resolve_s3`/`resolve_image_repos` were true. Turning them off and specifying bucket/repos directly avoids that error.

## How

- **`infra/github-deploy-policy.json`**: Least-privilege policy for the GitHub Actions deploy role with scoped access for CloudFormation stacks (`fide-glicko*`), the SAM S3 deploy bucket, `fide-glicko-*` Lambda functions, `fide-glicko-*` IAM roles, ECR repos (`fideglicko*`), and `fide-glicko-pipeline` Step Functions.
- **`samconfig.toml`**: Set `resolve_s3=false` and `resolve_image_repos=false`, and specify explicit `s3_bucket` and `image_repositories` for the 5 Image functions.

## Post-merge

1. Create an IAM policy from `infra/github-deploy-policy.json`.
2. Attach it to the `github-fide-glicko-deploy` role and remove `AmazonS3FullAccess` and `AWSLambda_FullAccess`.