### PR TITLE
fix(infra): Add cloudformation:GetTemplateSummary to GitHub deploy policy

### DIFF
--- a/infra/github-deploy-policy.json
+++ b/infra/github-deploy-policy.json
@@ -13,6 +13,7 @@
         "cloudformation:DescribeStackResource",
         "cloudformation:DescribeStackResources",
         "cloudformation:GetTemplate",
+        "cloudformation:GetTemplateSummary",
         "cloudformation:ListStackResources",
         "cloudformation:ValidateTemplate"
       ],


### PR DESCRIPTION
## What changed
Summary of the changes. Tip: feed `git diff --staged` to an AI if you want help writing this.

Add `cloudformation:GetTemplateSummary` to the GitHub deploy IAM policy.

## Why
Motivation, design decisions, empirical findings, etc.—anything that'd be useful beyond what someone (or an AI) could infer from the code alone.

SAM deploy calls `GetTemplateSummary` to read the stack template before create/update. Without it, the deploy fails with "User is not authorized to perform: cloudformation:GetTemplateSummary on resource". The policy was missing this action even though SAM needs it for the deployment flow.