### PR TITLE
fix(step-function): Default run_name to "test" when omitted for test runs

### DIFF
--- a/infra/step-function/pipeline.asl.json
+++ b/infra/step-function/pipeline.asl.json
@@ -1,7 +1,30 @@
 {
   "Comment": "FIDE scraping pipeline: federations, tournaments, player_list, split_ids, Map(details+reports per chunk), merge, validate",
-  "StartAt": "Federations",
+  "StartAt": "EnsureRunName",
   "States": {
+    "EnsureRunName": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.run_name",
+          "IsPresent": true,
+          "Next": "Federations"
+        }
+      ],
+      "Default": "AddDefaultRunName"
+    },
+    "AddDefaultRunName": {
+      "Type": "Pass",
+      "Parameters": {
+        "year.$": "$.year",
+        "month.$": "$.month",
+        "run_type.$": "$.run_type",
+        "run_name": "test",
+        "bucket.$": "$.bucket",
+        "override.$": "$.override"
+      },
+      "Next": "Federations"
+    },
     "Federations": {
       "Type": "Task",
       "Resource": "${FederationsFunctionArn}",


### PR DESCRIPTION
## What changed
Summary of the changes. Tip: feed `git diff --staged` to an AI if you want help writing this.

Add EnsureRunName and AddDefaultRunName states so that when run_name is missing from the pipeline input, it is set to "test" before Federations.

## Why
Motivation, design decisions, empirical findings, etc.—anything that'd be useful beyond what someone (or an AI) could infer from the code alone.

Lambdas treat run_name as optional for run_type "test" (build_run_base ignores it and uses "test"), but the Step Function passes parameters with JSONPath like `$.run_name`. If that path is missing, the state fails before the Lambda runs. Federations works because it only uses bucket and override. Tournaments is the first state that needs run_name, so it failed on input like `{ year, month, run_type: "test", bucket, override }` without run_name. The fix is a Choice + Pass at the start: if run_name is present, go to Federations; otherwise, add run_name: "test" and then go to Federations, matching the Lambda behavior where run_name is ignored for test.