### PR TITLE
fix: Resolve Docker Lambda import error, restructure pipeline flow, add import test

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,8 @@ FROM public.ecr.aws/lambda/python:3.12
 # Copy application code (DockerContext is repo root)
 COPY handlers /var/task/handlers
 COPY src /var/task/src
+# Scraper modules at root so "from get_player_list import", "from s3_io import" etc. resolve
+COPY src/scraper/*.py /var/task/
 
 # Install data deps (pandas, pyarrow, etc.)
 COPY docker/requirements.txt /var/task/

--- a/infra/step-function/README.md
+++ b/infra/step-function/README.md
@@ -1,12 +1,12 @@
 # FIDE Scraping Step Functions Pipeline
 
-Orchestrates the full scraping flow: federations → tournaments + player_list (parallel) → split_ids → Map(details + reports per chunk) → merge → validate.
+Orchestrates the full scraping flow: federations → tournaments → parallel(split_ids, player_list) → Map(details + reports per chunk) → merge → validate.
 
 ## Flow
 
 1. **Federations** – fetch federation list (shared across runs)
-2. **Parallel** – tournaments and player_list run in parallel
-3. **SplitIds** – chunk tournament IDs (~225 per chunk, ~75 chunks)
+2. **Tournaments** – fetch tournament IDs per federation
+3. **Parallel** – split_ids and player_list run in parallel (neither depends on the other)
 4. **Map** – each chunk runs details_chunk then reports_chunk (sequential per chunk; MaxConcurrency 40)
 5. **MergeChunks** – combine parquet outputs
 6. **Validate** – run validation report
@@ -56,8 +56,8 @@ aws stepfunctions get-execution-history --execution-arn EXECUTION_ARN
 ## Estimated duration
 
 - Federations: ~1 min
-- Tournaments + Player list (parallel): ~5–10 min
-- SplitIds: ~30 s
+- Tournaments: ~5–10 min
+- SplitIds + Player list (parallel): ~2 min
 - Map (details ~7.5 min + reports ~3.75 min per chunk, 40 concurrent): ~12–15 min
 - Merge + Validate: ~2 min
 

--- a/infra/step-function/pipeline.asl.json
+++ b/infra/step-function/pipeline.asl.json
@@ -1,5 +1,5 @@
 {
-  "Comment": "FIDE scraping pipeline: federations, tournaments, player_list, split_ids, Map(details+reports per chunk), merge, validate",
+  "Comment": "FIDE scraping pipeline: federations -> tournaments -> parallel(split_ids, player_list) -> Map(details+reports) -> merge -> validate",
   "StartAt": "EnsureRunName",
   "States": {
     "EnsureRunName": {
@@ -48,21 +48,49 @@
           "Next": "PipelineFailed"
         }
       ],
-      "Next": "ParallelData"
+      "Next": "Tournaments"
     },
 
-    "ParallelData": {
+    "Tournaments": {
+      "Type": "Task",
+      "Resource": "${TournamentsFunctionArn}",
+      "Parameters": {
+        "year.$": "$.year",
+        "month.$": "$.month",
+        "run_type.$": "$.run_type",
+        "run_name.$": "$.run_name",
+        "bucket.$": "$.bucket",
+        "override.$": "$.override"
+      },
+      "ResultPath": "$.tournaments",
+      "Retry": [
+        {
+          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "ResultPath": "$.error",
+          "Next": "PipelineFailed"
+        }
+      ],
+      "Next": "ParallelSplitIdsAndPlayerList"
+    },
+
+    "ParallelSplitIdsAndPlayerList": {
       "Type": "Parallel",
       "Branches": [
         {
-          "StartAt": "Tournaments",
+          "StartAt": "SplitIds",
           "States": {
-            "Tournaments": {
+            "SplitIds": {
               "Type": "Task",
-              "Resource": "${TournamentsFunctionArn}",
+              "Resource": "${SplitIdsFunctionArn}",
               "Parameters": {
-                "year.$": "$.year",
-                "month.$": "$.month",
                 "run_type.$": "$.run_type",
                 "run_name.$": "$.run_name",
                 "bucket.$": "$.bucket",
@@ -87,35 +115,7 @@
           }
         }
       ],
-      "ResultPath": "$.parallel_data",
-      "Retry": [
-        {
-          "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 3,
-          "BackoffRate": 2
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "ResultPath": "$.error",
-          "Next": "PipelineFailed"
-        }
-      ],
-      "Next": "SplitIds"
-    },
-
-    "SplitIds": {
-      "Type": "Task",
-      "Resource": "${SplitIdsFunctionArn}",
-      "Parameters": {
-        "run_type.$": "$.run_type",
-        "run_name.$": "$.run_name",
-        "bucket.$": "$.bucket",
-        "override.$": "$.override"
-      },
-      "ResultPath": "$.split_ids",
+      "ResultPath": "$.parallel_split_player",
       "Retry": [
         {
           "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
@@ -136,7 +136,7 @@
 
     "MapDetailsAndReports": {
       "Type": "Map",
-      "ItemsPath": "$.split_ids.chunks",
+      "ItemsPath": "$.parallel_split_player[0].chunks",
       "MaxConcurrency": 40,
       "ItemSelector": {
         "run_type.$": "$$.Execution.Input.run_type",

--- a/tests/test_lambda_imports.py
+++ b/tests/test_lambda_imports.py
@@ -8,6 +8,15 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
+# Handler modules for container (Docker) Lambdas. Verifies scraper modules at /var/task/.
+IMAGE_HANDLERS = [
+    "handlers.player_list",
+    "handlers.details_chunk",
+    "handlers.reports_chunk",
+    "handlers.merge_chunks",
+    "handlers.validate",
+]
+
 # (SAM logical ID, handler_module)
 # Only "light" Lambdas (no pandas/pyarrow) - those with pandas have ABI issues when
 # tested with local Python 3.13 vs Lambda 3.12; they are validated by deploy workflow.
@@ -65,4 +74,48 @@ assert hasattr(mod, "lambda_handler")
         f"Failed to import {handler_module} from {logical_id}:\n"
         f"stdout={result.stdout}\nstderr={result.stderr}\n"
         f"Ensure all transitive deps are in requirements.txt."
+    )
+
+
+def test_docker_image_handler_imports():
+    """Build Docker image and verify all image handlers can import.
+
+    Catches missing scraper modules at /var/task/ (e.g. No module named 'get_player_list').
+    Uses the same Dockerfile and context as SAM deploy.
+    """
+    result = subprocess.run(["docker", "version"], capture_output=True)
+    if result.returncode != 0:
+        pytest.skip("Docker not available; run in environment with Docker")
+
+    image_tag = "fide-glicko-data:import-test"
+
+    build_result = subprocess.run(
+        ["docker", "build", "-f", "docker/Dockerfile", "-t", image_tag, "."],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert (
+        build_result.returncode == 0
+    ), f"Docker build failed:\n{build_result.stdout}\n{build_result.stderr}"
+
+    import_lines = "\n".join(f"import {m}" for m in IMAGE_HANDLERS)
+    run_result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "python3",
+            image_tag,
+            "-c",
+            f"{import_lines}\nprint('ok')",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert run_result.returncode == 0, (
+        f"Failed to import image handlers in container:\n"
+        f"stdout={run_result.stdout}\nstderr={run_result.stderr}\n"
+        f"Ensure scraper modules are copied to /var/task/ in Dockerfile."
     )


### PR DESCRIPTION
## What changed
- **Dockerfile**: Copy `src/scraper/*.py` into `/var/task/` so image Lambdas can resolve `from get_player_list import`, `from s3_io import`, etc.
- **Step Function**: Change flow from federations → parallel(tournaments, player_list) → split_ids to federations → tournaments → parallel(split_ids, player_list). Adjust Map `ItemsPath` from `$.split_ids.chunks` to `$.parallel_split_player[0].chunks`.
- **Tests**: Add `test_docker_image_handler_imports` to build the Docker image and verify all 5 image handlers import inside the container.

## Why
- **Import fix**: The Player List Lambda (and others) failed at runtime with `No module named 'get_player_list'` because handlers use top-level imports like `from get_player_list import run_shared`, but scraper modules were not at `/var/task/`. Copying them there makes the imports resolve in the Lambda runtime.
- **Pipeline restructure**: SplitIds needs tournament IDs (from Tournaments). PlayerList needs only federations. Neither needs the other. Running Tournaments first, then parallel(SplitIds, PlayerList) removes an unnecessary dependency: SplitIds no longer runs before Tournaments completes, and both SplitIds and PlayerList can run in parallel. The Map step now uses `$.parallel_split_player[0].chunks` because SplitIds is the first parallel branch.
- **Import test**: The existing import tests only cover ZIP Lambdas. Adding a test that builds the Docker image and runs imports inside the container catches missing scraper modules at `/var/task/` and prevents this regression.