### PR TITLE
fix: Fail Tournaments when any federation errors, add SplitIds guard in pipeline

### DIFF
--- a/infra/step-function/pipeline.asl.json
+++ b/infra/step-function/pipeline.asl.json
@@ -131,7 +131,25 @@
           "Next": "PipelineFailed"
         }
       ],
-      "Next": "MapDetailsAndReports"
+      "Next": "CheckSplitIdsSuccess"
+    },
+
+    "CheckSplitIdsSuccess": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.parallel_split_player[0].success",
+          "BooleanEquals": false,
+          "Next": "SplitIdsFailed"
+        }
+      ],
+      "Default": "MapDetailsAndReports"
+    },
+
+    "SplitIdsFailed": {
+      "Type": "Fail",
+      "Error": "SplitIdsFailed",
+      "Cause.$": "$.parallel_split_player[0].error"
     },
 
     "MapDetailsAndReports": {

--- a/src/scraper/get_tournaments.py
+++ b/src/scraper/get_tournaments.py
@@ -513,7 +513,7 @@ async def scrape_month(
         logger.info("Read %d federations from %s", len(federations), federations_path)
     except Exception as e:
         logger.error(f"Error reading federations: {e}")
-        return []
+        return [], 0, 0
 
     logger.info(
         f"Processing {len(federations)} federations for {year}-{month:02d} "
@@ -693,7 +693,21 @@ async def scrape_month(
         print(f"  By time control: {tc_counts}")
     print("=" * 80)
 
-    return unique_tournaments
+    return unique_tournaments, len(errors), len(federations)
+
+
+def _scrape_exit_code(n_errors: int, n_total: int) -> int:
+    """
+    Return exit code for scrape outcome.
+
+    - 0: All federations succeeded (or no federations to process).
+    - 1: Any federation failed — fail so we don't use partial/incomplete data.
+    """
+    if n_total == 0:
+        return 0
+    if n_errors > 0:
+        return 1
+    return 0
 
 
 def run(
@@ -760,7 +774,7 @@ def run(
         return 1
 
     try:
-        asyncio.run(
+        _, n_errors, n_total = asyncio.run(
             scrape_month(
                 year,
                 month,
@@ -771,7 +785,7 @@ def run(
                 json_uri=json_uri,
             )
         )
-        return 0
+        return _scrape_exit_code(n_errors, n_total)
     except Exception as e:
         logger.error("Fatal error: %s", e)
         return 1
@@ -924,7 +938,7 @@ def main() -> int:
 
     # Run the scraper
     try:
-        asyncio.run(
+        _, n_errors, n_total = asyncio.run(
             scrape_month(
                 args.year,
                 args.month,
@@ -939,7 +953,7 @@ def main() -> int:
                 save_raw=not args.no_save_raw,
             )
         )
-        return 0
+        return _scrape_exit_code(n_errors, n_total)
     except KeyboardInterrupt:
         logger.info("Interrupted by user")
         return 130  # Standard exit code for SIGINT


### PR DESCRIPTION
## What changed
- **Tournaments scraper**: Treat any federation failure as a hard failure. `scrape_month` now returns `(tournaments, n_errors, n_total)` and uses a non-zero exit code when `n_errors > 0`, so the Lambda returns 500 instead of success with partial data.
- **Step Function**: Insert a Choice state after the Parallel step to check SplitIds success. When `$.parallel_split_player[0].success` is false, transition to a dedicated Fail state that surfaces the SplitIds error instead of letting Map fail with "Unable to apply step 'chunks'" when `.chunks` is missing.

## Why
- **Tournaments**: In AWS Lambda, all 208 federation requests were failing (connection refused/timeout to ratings.fide.com), but the scraper still returned success and wrote an empty `tournament_ids.txt`. Downstream SplitIds produced no chunks, and the pipeline failed in a confusing way. The requirement is strict: if any federation fails, treat the run as failed and avoid partial or empty data.
- **SplitIds guard**: When SplitIds returns `success: false` (e.g. empty tournament list), there is no `chunks` key. The Map step uses `ItemsPath: "$.parallel_split_player[0].chunks"`, so it would fail with "Unable to apply step 'chunks'" instead of a clear SplitIds error. The Choice state checks SplitIds success before Map and routes to a Fail state that exposes the actual error (e.g. "Split produced no chunks").