### PR TITLE
fix: Use CausePath in Fail state for Step Functions compatibility

### DIFF
--- a/infra/step-function/pipeline.asl.json
+++ b/infra/step-function/pipeline.asl.json
@@ -149,7 +149,7 @@
     "SplitIdsFailed": {
       "Type": "Fail",
       "Error": "SplitIdsFailed",
-      "Cause.$": "$.parallel_split_player[0].error"
+      "CausePath": "$.parallel_split_player[0].error"
     },
 
     "MapDetailsAndReports": {


### PR DESCRIPTION
## What changed
In the `SplitIdsFailed` Fail state, `Cause.$` is replaced with `CausePath` for the dynamic error message.

## Why
After merging #56, the SAM deploy failed and the stack rolled back (UPDATE_ROLLBACK_COMPLETE). Step Functions Fail states use `CausePath` for dynamic JSONPath values, not `Cause.$`. `Cause.$` is valid in Task/Pass `Parameters`, but not in Fail; using it can make the state machine definition invalid and cause deploy failures. Swapping to `CausePath` keeps the behavior (exposing the SplitIds error, e.g. "Split produced no chunks") while matching the correct API.