### PR TITLE
fix(step-function): Reduce Map concurrency, add ResultPath, improve 429 retries

### DIFF
--- a/infra/step-function/README.md
+++ b/infra/step-function/README.md
@@ -7,7 +7,7 @@ Orchestrates the full scraping flow: federations → tournaments → parallel(sp
 1. **Federations** – fetch federation list (shared across runs)
 2. **Tournaments** – fetch tournament IDs per federation
 3. **Parallel** – split_ids and player_list run in parallel (neither depends on the other)
-4. **Map** – each chunk runs details_chunk then reports_chunk (sequential per chunk; MaxConcurrency 40)
+4. **Map** – each chunk runs details_chunk then reports_chunk (sequential per chunk; MaxConcurrency 15)
 5. **MergeChunks** – combine parquet outputs
 6. **Validate** – run validation report
 
@@ -58,7 +58,7 @@ aws stepfunctions get-execution-history --execution-arn EXECUTION_ARN
 - Federations: ~1 min
 - Tournaments: ~5–10 min
 - SplitIds + Player list (parallel): ~2 min
-- Map (details ~7.5 min + reports ~3.75 min per chunk, 40 concurrent): ~12–15 min
+- Map (details ~7.5 min + reports ~3.75 min per chunk, 15 concurrent): ~20–25 min
 - Merge + Validate: ~2 min
 
 **Total: ~25–35 min**

--- a/infra/step-function/pipeline.asl.json
+++ b/infra/step-function/pipeline.asl.json
@@ -155,7 +155,7 @@
     "MapDetailsAndReports": {
       "Type": "Map",
       "ItemsPath": "$.parallel_split_player[0].chunks",
-      "MaxConcurrency": 40,
+      "MaxConcurrency": 15,
       "ItemSelector": {
         "run_type.$": "$$.Map.Item.Value.run_type",
         "run_name.$": "$$.Map.Item.Value.run_name",
@@ -176,9 +176,16 @@
               "bucket.$": "$.bucket",
               "override.$": "$.override"
             },
+            "ResultPath": "$.details_result",
             "Retry": [
               {
-                "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+                "ErrorEquals": ["Lambda.TooManyRequestsException"],
+                "IntervalSeconds": 10,
+                "MaxAttempts": 6,
+                "BackoffRate": 2
+              },
+              {
+                "ErrorEquals": ["Lambda.ServiceException"],
                 "IntervalSeconds": 5,
                 "MaxAttempts": 3,
                 "BackoffRate": 2
@@ -206,7 +213,13 @@
             },
             "Retry": [
               {
-                "ErrorEquals": ["Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+                "ErrorEquals": ["Lambda.TooManyRequestsException"],
+                "IntervalSeconds": 10,
+                "MaxAttempts": 6,
+                "BackoffRate": 2
+              },
+              {
+                "ErrorEquals": ["Lambda.ServiceException"],
                 "IntervalSeconds": 5,
                 "MaxAttempts": 3,
                 "BackoffRate": 2


### PR DESCRIPTION
## What changed
- **MaxConcurrency**: 40 → 15 to lower Lambda invocation rate and avoid 429 throttling
- **DetailsChunk ResultPath**: Add `ResultPath: "$.details_result"` so the Lambda result is stored under a key instead of overwriting the state, keeping `run_type`, `run_name`, `chunk_index`, `bucket`, and `override` available for ReportsChunk
- **429 retries**: Separate retry policy for `Lambda.TooManyRequestsException` (IntervalSeconds 10, MaxAttempts 6, BackoffRate 2) for DetailsChunk and ReportsChunk
- **README**: Update concurrency and duration estimates

## Why
- **429 rate limits**: At 40 concurrent Map iterations, DetailsChunk (and later ReportsChunk) hit Lambda rate limits. Lowering concurrency reduces throttling; stronger retries give time for limits to reset.
- **ReportsChunk JSONPath**: DetailsChunk’s output was replacing the iteration state, so ReportsChunk only saw the Lambda response and not the original parameters. `ResultPath` keeps the original input fields and adds the Lambda output under `details_result`.
- **Trade-off**: Map phase runtime increases (approx. 20–25 min vs. 12–15 min) in exchange for more reliable execution and fewer 429 failures.