### PR TITLE
feat(step-function): Make Map max concurrency configurable via execution input

### DIFF
--- a/infra/step-function/README.md
+++ b/infra/step-function/README.md
@@ -7,7 +7,7 @@ Orchestrates the full scraping flow: federations → tournaments → parallel(sp
 1. **Federations** – fetch federation list (shared across runs)
 2. **Tournaments** – fetch tournament IDs per federation
 3. **Parallel** – split_ids and player_list run in parallel (neither depends on the other)
-4. **Map** – each chunk runs details_chunk then reports_chunk (sequential per chunk; MaxConcurrency 15)
+4. **Map** – each chunk runs details_chunk then reports_chunk (sequential per chunk; MaxConcurrency configurable via input, default 5)
 5. **MergeChunks** – combine parquet outputs
 6. **Validate** – run validation report
 
@@ -44,6 +44,7 @@ aws stepfunctions start-execution \
 - **run_name** – e.g. `2024-01` (required for prod/custom)
 - **bucket** – S3 bucket (default: fide-glicko)
 - **override** – if true, refetch/overwrite even when cached (default: false)
+- **max_concurrency** – Map state parallelism for chunk processing (default: 5)
 - **chunk_size** – optional; Lambda default is 225
 
 ## Check status
@@ -58,7 +59,7 @@ aws stepfunctions get-execution-history --execution-arn EXECUTION_ARN
 - Federations: ~1 min
 - Tournaments: ~5–10 min
 - SplitIds + Player list (parallel): ~2 min
-- Map (details ~7.5 min + reports ~3.75 min per chunk, 15 concurrent): ~20–25 min
+- Map (details ~7.5 min + reports ~3.75 min per chunk, 5 concurrent): ~45–60 min
 - Merge + Validate: ~2 min
 
 **Total: ~25–35 min**

--- a/infra/step-function/pipeline.asl.json
+++ b/infra/step-function/pipeline.asl.json
@@ -143,7 +143,36 @@
           "Next": "SplitIdsFailed"
         }
       ],
-      "Default": "MapDetailsAndReports"
+      "Default": "CheckMaxConcurrency"
+    },
+
+    "CheckMaxConcurrency": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.max_concurrency",
+          "IsPresent": true,
+          "Next": "MapDetailsAndReports"
+        }
+      ],
+      "Default": "EnsureMaxConcurrency"
+    },
+
+    "EnsureMaxConcurrency": {
+      "Type": "Pass",
+      "Parameters": {
+        "year.$": "$.year",
+        "month.$": "$.month",
+        "run_type.$": "$.run_type",
+        "run_name.$": "$.run_name",
+        "bucket.$": "$.bucket",
+        "override.$": "$.override",
+        "federations.$": "$.federations",
+        "tournaments.$": "$.tournaments",
+        "parallel_split_player.$": "$.parallel_split_player",
+        "max_concurrency": 5
+      },
+      "Next": "MapDetailsAndReports"
     },
 
     "SplitIdsFailed": {
@@ -155,7 +184,7 @@
     "MapDetailsAndReports": {
       "Type": "Map",
       "ItemsPath": "$.parallel_split_player[0].chunks",
-      "MaxConcurrency": 15,
+      "MaxConcurrencyPath": "$.max_concurrency",
       "ItemSelector": {
         "run_type.$": "$$.Map.Item.Value.run_type",
         "run_name.$": "$$.Map.Item.Value.run_name",


### PR DESCRIPTION
## What changed
Make Map state max concurrency configurable at execution time via the `max_concurrency` input field, with a default of 5 when omitted. Previously it was fixed at 15 in the pipeline definition.

## Why
- **Avoid repeated PRs** – Concurrency can be tuned without changing pipeline code (e.g. temporary increases to speed a run).
- **Account limits** – Lambda default is 10 concurrent executions per account; a conservative default of 5 reduces risk of throttling.
- **Step Functions limitation** – `MaxConcurrency` must be a static integer; `MaxConcurrencyPath` is used to read the value from state at runtime.
- **Choice + Pass pattern** – Step Functions has no “use X if present else default” intrinsic, so a Choice checks for `$.max_concurrency` and an `EnsureMaxConcurrency` Pass injects `5` when it’s missing, before the Map.

## How
- Added `CheckMaxConcurrency` (Choice) and `EnsureMaxConcurrency` (Pass) between `CheckSplitIdsSuccess` and the Map.
- Switched Map from `MaxConcurrency: 15` to `MaxConcurrencyPath: "$.max_concurrency"`.
- Documented `max_concurrency` in the Step Function README and revised duration estimates for the 5-concurrency default.

## Testing
- `python scripts/validate_step_function.py` (static ASL checks)
- No changes to existing tests; `ItemSelector` still uses `$$.Execution.Input.bucket`/`override`, not `max_concurrency`.

## Notes / Follow-ups
- Default is 5; pass `max_concurrency` in the execution input to override.