### PR TITLE
feat(step-function): Derive prod run_name as YYYY-MM, improve docs, fix S3 structure, default max_concurrency 10

### DIFF
--- a/.github/workflows/deploy-sam.yml
+++ b/.github/workflows/deploy-sam.yml
@@ -105,7 +105,7 @@ jobs:
               definition = f.read()
 
           placeholder = 'arn:aws:lambda:${{ vars.AWS_REGION || 'us-east-1' }}:123456789012:function:placeholder'
-          for var in ['FederationsFunctionArn', 'TournamentsFunctionArn', 'PlayerListFunctionArn',
+          for var in ['EnsureRunNameFunctionArn', 'FederationsFunctionArn', 'TournamentsFunctionArn', 'PlayerListFunctionArn',
                       'SplitIdsFunctionArn', 'DetailsChunkFunctionArn', 'ReportsChunkFunctionArn',
                       'MergeChunksFunctionArn', 'ValidateFunctionArn']:
               definition = definition.replace('\${' + var + '}', placeholder)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ The project includes Python scripts for scraping tournament data from the FIDE w
    ```
    See [scripts/README.md](scripts/README.md) for details.
 
+### AWS Step Function (deployed pipeline)
+
+When deployed to AWS, the pipeline runs as a Step Function. To start a production run for a given month:
+
+```bash
+aws stepfunctions start-execution \
+  --state-machine-arn arn:aws:states:REGION:ACCOUNT:stateMachine:fide-glicko-pipeline \
+  --name "run-$(date +%Y%m%d-%H%M%S)" \
+  --input '{"year": 2025, "month": 3, "run_type": "prod"}'
+```
+
+For prod, `run_name` is derived as `YYYY-MM`; no need to pass it. See [infra/step-function/README.md](infra/step-function/README.md) for full options and [infra/README.md](infra/README.md) for deploy and S3 layout.
+
 The scraper outputs data in efficient Parquet format with JSON samples for quick inspection. See the [scraper README](src/scraper/README.md) for complete documentation.
 
 ## Testing

--- a/handlers/README.md
+++ b/handlers/README.md
@@ -2,7 +2,22 @@
 
 All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where applicable. Paths are inferred from these; explicit URIs are optional overrides.
 
+**Prod runs:** `run_name` is derived as `YYYY-MM` from year and month by the pipeline; Lambdas receive it from state. For custom runs, `run_name` is required.
+
 ## Event Shapes (minimal = run params only)
+
+### ensure_run_name
+```json
+{
+  "year": 2025,
+  "month": 3,
+  "run_type": "prod",
+  "bucket": "fide-glicko",
+  "override": false
+}
+```
+- Normalizes `run_name` before pipeline: prod = `{year}-{month:02d}`, custom = required, test = `"test"`
+- Returns full passthrough with `run_name` set. Called first by the Step Function.
 
 ### federations
 ```json
@@ -22,13 +37,13 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
   "year": 2025,
   "month": 3,
   "run_type": "prod",
-  "run_name": "2024-01",
+  "run_name": "2025-03",
   "bucket": "fide-glicko",
   "override": false
 }
 ```
 - **year**, **month**: Required
-- **run_type**, **run_name**: As above
+- **run_type**, **run_name**: run_name comes from EnsureRunName (prod: YYYY-MM; custom: user-provided)
 - **federations_s3_uri**: Optional. Defaults to latest in `{bucket}/federations/data/`
 - Outputs: `{base}/data/tournament_ids.txt`, `{base}/sample/tournament_ids_sample.json`, `{base}/raw/tournaments.json.gz` (raw API JSON, all federations concatenated, gzip-9)
 
@@ -129,7 +144,7 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
 
 ## Path formula
 
-- **base** = `{run_type}/{run_name}` for prod/custom, or `test` for run_type=test
+- **base** = `prod/{YYYY-MM}` for prod, `custom/{run_name}` for custom, or `test` for run_type=test
 - **Shared** (federations, player list): `{bucket}/federations/data/federations_{timestamp}.csv`, `{bucket}/player_lists/data/player_list_{timestamp}.parquet`, `{bucket}/player_lists/raw/player_list_{timestamp}.xml.gz` — all run types share these; 2-week staleness check.
 - **Per-run data**: `{bucket}/{base}/data/...`
 - **raw**: `{bucket}/{base}/raw/...` (compressed downloads)

--- a/handlers/ensure_run_name.py
+++ b/handlers/ensure_run_name.py
@@ -1,0 +1,52 @@
+"""
+Lambda handler to normalize run_name before pipeline execution.
+
+For prod: run_name is always derived from year-month (YYYY-MM) to avoid repeat runs.
+For custom: run_name is required (user-defined).
+For test: run_name defaults to "test" when omitted.
+
+Event shape (passthrough from execution input):
+{
+    "year": 2025,
+    "month": 3,
+    "run_type": "prod",
+    "run_name": null,
+    "bucket": "fide-glicko",
+    "override": false,
+    "max_concurrency": 5
+}
+
+Returns the same input with run_name set. Fails with 400 if validation fails.
+"""
+
+
+def lambda_handler(event: dict, context) -> dict:
+    """Normalize run_name and return full passthrough for pipeline."""
+    # Step Function passes full state as {"input": {...}}
+    data = event.get("input", event)
+    run_type = data.get("run_type", "custom")
+    run_name = data.get("run_name")
+    year = data.get("year")
+    month = data.get("month")
+
+    if run_type not in ("prod", "custom", "test"):
+        raise ValueError(
+            f"run_type must be one of prod, custom, test (got {run_type!r})"
+        )
+
+    if run_type == "prod":
+        if year is None or month is None:
+            raise ValueError("year and month are required for prod runs")
+        run_name = f"{int(year)}-{int(month):02d}"
+    elif run_type == "custom":
+        if not run_name:
+            raise ValueError("run_name is required for custom runs")
+    else:
+        run_name = run_name or "test"
+
+    out = dict(data)
+    out["run_name"] = run_name
+    # Apply defaults for optional fields
+    out.setdefault("bucket", "fide-glicko")
+    out.setdefault("override", False)
+    return out

--- a/infra/README.md
+++ b/infra/README.md
@@ -61,39 +61,75 @@ If you previously deployed with the old shell scripts, the Lambdas and Step Func
 - **8 Lambda functions**: federations, tournaments, player_list, split_ids, details_chunk, reports_chunk, merge_chunks, validate
 - **1 Step Functions state machine**: fide-glicko-pipeline
 
-All Lambdas share the same code package (handlers + `src/scraper`). The Step Function orchestrates the full scraping flow. See [step-function/README.md](step-function/README.md) for pipeline details and run instructions.
+All Lambdas share the same code package (handlers + `src/scraper`). The Step Function orchestrates the full scraping flow.
+
+**Run the pipeline:**
+```bash
+# Get state machine ARN from deploy output (or: aws stepfunctions list-state-machines)
+aws stepfunctions start-execution \
+  --state-machine-arn arn:aws:states:REGION:ACCOUNT:stateMachine:fide-glicko-pipeline \
+  --name "run-$(date +%Y%m%d-%H%M%S)" \
+  --input '{"year": 2025, "month": 3, "run_type": "prod", "bucket": "fide-glicko"}'
+```
+For prod, omit `run_name`; it is derived as `YYYY-MM`. See [step-function/README.md](step-function/README.md) for full input options.
 
 ---
 
 ## S3 Bucket Structure
 
-The `fide-glicko` bucket stores scraped data. Layout:
+The `fide-glicko` bucket stores scraped data. Layout (mirrors `build_run_base` + `build_s3_uri_for_run`):
 
 ```
 s3://fide-glicko/
-├── data/                           # Production data (monthly runs, canonical)
-│   ├── federations.csv             # Shared across all months
-│   ├── players_list.parquet        # Shared, updated periodically
-│   ├── tournament_ids/
-│   │   └── {YYYY_MM}
-│   ├── tournament_details/
-│   │   └── {YYYY_MM}.parquet
-│   ├── tournament_reports/
-│   │   ├── {YYYY_MM}_players.parquet
-│   │   └── {YYYY_MM}_games.parquet
-│   └── validation_reports/
-│       └── {YYYY_MM}.txt
+├── federations/                    # Shared across all run types
+│   └── data/
+│       └── federations_{timestamp}.csv
 │
-└── runs/                           # Dev/test runs (isolated by run_id)
-    └── {run_id}/
-        ├── federations.csv
-        ├── tournament_ids/
-        ├── tournament_details/
-        └── ...
+├── player_lists/                  # Shared across all run types
+│   ├── data/
+│   │   └── player_list_{timestamp}.parquet
+│   ├── raw/
+│   │   └── player_list_{timestamp}.xml.gz
+│   ├── sample/
+│   │   └── player_list_sample_{timestamp}.json
+│   └── reports/
+│       └── player_list_report_{timestamp}.json
+│
+├── prod/                          # Production runs (one per month)
+│   └── {YYYY-MM}/                 # e.g. 2024-01
+│       ├── data/
+│       │   ├── tournament_ids.txt
+│       │   ├── tournament_id_chunks/
+│       │   │   └── chunk_{N}.txt
+│       │   ├── tournament_details_chunks/
+│       │   │   └── chunk_{N}.parquet
+│       │   ├── tournament_reports_chunks/
+│       │   │   ├── chunk_{N}_players.parquet
+│       │   │   └── chunk_{N}_games.parquet
+│       │   ├── tournament_details.parquet
+│       │   ├── tournament_reports_players.parquet
+│       │   └── tournament_reports_games.parquet
+│       ├── sample/
+│       │   └── tournament_ids_sample.json
+│       ├── raw/
+│       │   └── tournaments.json.gz
+│       ├── reports/
+│       │   └── validation_report.json
+│       └── run_metadata.json
+│
+├── custom/                        # Custom/backfill runs (user-named)
+│   └── {run_name}/
+│       └── ...                    # Same structure as prod/{YYYY-MM}
+│
+└── test/                          # Test runs (no run_name subfolder)
+    ├── data/
+    │   └── ...
+    └── ...
 ```
 
-- **`data/`** – Scheduled production runs. Use `run_type: prod`, `run_name: "2024-01"`, etc.
-- **`runs/{run_id}/`** – Dev, test, backfills. Use `run_type: custom` or `test`.
+- **`prod/{YYYY-MM}/`** – Scheduled monthly runs. Pass `run_type: "prod"` with `year` and `month`; `run_name` is derived.
+- **`custom/{run_name}/`** – Dev, backfills. Pass `run_type: "custom"` and `run_name`.
+- **`test/`** – Test runs. Pass `run_type: "test"`; `run_name` defaults to `"test"`.
 
 ## Logs
 

--- a/infra/step-function/README.md
+++ b/infra/step-function/README.md
@@ -1,13 +1,14 @@
 # FIDE Scraping Step Functions Pipeline
 
-Orchestrates the full scraping flow: federations → tournaments → parallel(split_ids, player_list) → Map(details + reports per chunk) → merge → validate.
+Orchestrates the full scraping flow: ensure_run_name → federations → tournaments → parallel(split_ids, player_list) → Map(details + reports per chunk) → merge → validate.
 
 ## Flow
 
+0. **EnsureRunName** – normalize `run_name`: prod = `YYYY-MM` from year/month; custom = required; test = default `"test"`
 1. **Federations** – fetch federation list (shared across runs)
 2. **Tournaments** – fetch tournament IDs per federation
 3. **Parallel** – split_ids and player_list run in parallel (neither depends on the other)
-4. **Map** – each chunk runs details_chunk then reports_chunk (sequential per chunk; MaxConcurrency configurable via input, default 5)
+4. **Map** – each chunk runs details_chunk then reports_chunk (sequential per chunk; MaxConcurrency configurable via input, default 10)
 5. **MergeChunks** – combine parquet outputs
 6. **Validate** – run validation report
 
@@ -21,8 +22,9 @@ sam build && sam deploy
 
 ## Run
 
-Start an execution with the required input:
+Start an execution with the required input. For **prod**, omit `run_name` — it is always derived as `YYYY-MM` from year and month to avoid repeat runs.
 
+**Production (monthly run):**
 ```bash
 aws stepfunctions start-execution \
   --state-machine-arn arn:aws:states:REGION:ACCOUNT:stateMachine:fide-glicko-pipeline \
@@ -31,20 +33,39 @@ aws stepfunctions start-execution \
     "year": 2025,
     "month": 3,
     "run_type": "prod",
-    "run_name": "2024-01",
     "bucket": "fide-glicko",
     "override": false
   }'
+```
+
+**Custom (backfill, dev):**
+```bash
+aws stepfunctions start-execution \
+  --state-machine-arn arn:aws:states:REGION:ACCOUNT:stateMachine:fide-glicko-pipeline \
+  --name "backfill-2024-06" \
+  --input '{
+    "year": 2024,
+    "month": 6,
+    "run_type": "custom",
+    "run_name": "backfill-2024-06",
+    "bucket": "fide-glicko"
+  }'
+```
+
+**Test:**
+```bash
+# run_name defaults to "test" when omitted
+--input '{"year": 2025, "month": 1, "run_type": "test"}'
 ```
 
 **Input fields:**
 
 - **year**, **month** (required) – for tournaments step
 - **run_type** – `prod`, `custom`, or `test`
-- **run_name** – e.g. `2024-01` (required for prod/custom)
+- **run_name** – For prod: omit (derived as `YYYY-MM`). For custom: required (e.g. `"backfill-2024-06"`). For test: optional (default `"test"`)
 - **bucket** – S3 bucket (default: fide-glicko)
 - **override** – if true, refetch/overwrite even when cached (default: false)
-- **max_concurrency** – Map state parallelism for chunk processing (default: 5)
+- **max_concurrency** – Map state parallelism for chunk processing (default: 10)
 - **chunk_size** – optional; Lambda default is 225
 
 ## Check status
@@ -59,7 +80,7 @@ aws stepfunctions get-execution-history --execution-arn EXECUTION_ARN
 - Federations: ~1 min
 - Tournaments: ~5–10 min
 - SplitIds + Player list (parallel): ~2 min
-- Map (details ~7.5 min + reports ~3.75 min per chunk, 5 concurrent): ~45–60 min
+- Map (details ~7.5 min + reports ~3.75 min per chunk, 10 concurrent): ~25–35 min
 - Merge + Validate: ~2 min
 
 **Total: ~25–35 min**

--- a/infra/step-function/pipeline.asl.json
+++ b/infra/step-function/pipeline.asl.json
@@ -1,28 +1,21 @@
 {
-  "Comment": "FIDE scraping pipeline: federations -> tournaments -> parallel(split_ids, player_list) -> Map(details+reports) -> merge -> validate",
+  "Comment": "FIDE scraping pipeline: ensure_run_name -> federations -> tournaments -> parallel(split_ids, player_list) -> Map(details+reports) -> merge -> validate",
   "StartAt": "EnsureRunName",
   "States": {
     "EnsureRunName": {
-      "Type": "Choice",
-      "Choices": [
+      "Type": "Task",
+      "Resource": "${EnsureRunNameFunctionArn}",
+      "Parameters": {
+        "input.$": "$"
+      },
+      "ResultPath": "$",
+      "Catch": [
         {
-          "Variable": "$.run_name",
-          "IsPresent": true,
-          "Next": "Federations"
+          "ErrorEquals": ["States.ALL"],
+          "ResultPath": "$.error",
+          "Next": "PipelineFailed"
         }
       ],
-      "Default": "AddDefaultRunName"
-    },
-    "AddDefaultRunName": {
-      "Type": "Pass",
-      "Parameters": {
-        "year.$": "$.year",
-        "month.$": "$.month",
-        "run_type.$": "$.run_type",
-        "run_name": "test",
-        "bucket.$": "$.bucket",
-        "override.$": "$.override"
-      },
       "Next": "Federations"
     },
     "Federations": {
@@ -170,7 +163,7 @@
         "federations.$": "$.federations",
         "tournaments.$": "$.tournaments",
         "parallel_split_player.$": "$.parallel_split_player",
-        "max_concurrency": 5
+        "max_concurrency": 10
       },
       "Next": "MapDetailsAndReports"
     },

--- a/scripts/prepare_functions.sh
+++ b/scripts/prepare_functions.sh
@@ -27,9 +27,10 @@ REQS[federations]="requests>=2.32.5
 beautifulsoup4>=4.14.3"
 REQS[tournaments]="aiohttp>=3.10.0"
 REQS[split_ids]=""
+REQS[ensure_run_name]=""
 
 # Put scraper modules at function root so "from get_federations import" etc. resolve
-for name in federations tournaments split_ids; do
+for name in federations tournaments split_ids ensure_run_name; do
   dir="$FUNCTIONS_DIR/$name"
   mkdir -p "$dir"
   link_or_copy "$REPO_ROOT/handlers" "$dir/"

--- a/template.yaml
+++ b/template.yaml
@@ -16,6 +16,17 @@ Globals:
       - x86_64
 
 Resources:
+  EnsureRunNameFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: fide-glicko-ensure-run-name
+      Runtime: python3.12
+      CodeUri: .functions/ensure_run_name
+      Handler: handlers.ensure_run_name.lambda_handler
+      Timeout: 10
+      MemorySize: 128
+      Description: Normalize run_name for pipeline (prod=YYYY-MM, custom=required, test=default)
+
   FederationsFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -159,6 +170,7 @@ Resources:
       Name: fide-glicko-pipeline
       DefinitionUri: infra/step-function/pipeline.asl.json
       DefinitionSubstitutions:
+        EnsureRunNameFunctionArn: !GetAtt EnsureRunNameFunction.Arn
         FederationsFunctionArn: !GetAtt FederationsFunction.Arn
         TournamentsFunctionArn: !GetAtt TournamentsFunction.Arn
         PlayerListFunctionArn: !GetAtt PlayerListFunction.Arn
@@ -173,6 +185,7 @@ Resources:
             - Effect: Allow
               Action: lambda:InvokeFunction
               Resource:
+                - !GetAtt EnsureRunNameFunction.Arn
                 - !GetAtt FederationsFunction.Arn
                 - !GetAtt TournamentsFunction.Arn
                 - !GetAtt PlayerListFunction.Arn

--- a/tests/test_lambda_imports.py
+++ b/tests/test_lambda_imports.py
@@ -21,6 +21,7 @@ IMAGE_HANDLERS = [
 # Only "light" Lambdas (no pandas/pyarrow) - those with pandas have ABI issues when
 # tested with local Python 3.13 vs Lambda 3.12; they are validated by deploy workflow.
 LAMBDA_CONFIGS = [
+    ("EnsureRunNameFunction", "handlers.ensure_run_name"),
     ("FederationsFunction", "handlers.federations"),
     ("TournamentsFunction", "handlers.tournaments"),
     ("SplitIdsFunction", "handlers.split_ids"),

--- a/tests/test_step_function.py
+++ b/tests/test_step_function.py
@@ -77,7 +77,7 @@ def test_no_fail_state_uses_cause_dollar() -> None:
 
 
 def test_no_execution_input_refs_to_defaulted_fields() -> None:
-    """ItemSelector must not use $$.Execution.Input for fields defaulted by AddDefaultRunName."""
+    """ItemSelector must not use $$.Execution.Input for fields defaulted by EnsureRunName."""
     definition = _load_pipeline()
     defaulted = _find_defaulted_fields(definition)
     violations = []


### PR DESCRIPTION
## What
- For prod runs, derive `run_name` from year/month (`YYYY-MM`) so it’s not required in execution input.
- Add EnsureRunName Lambda as the first pipeline step.
- Update S3 bucket docs to match the code layout.
- Add AWS Step Function run instructions to top-level and infra READMEs.
- Increase Map `max_concurrency` default from 5 to 10.

## Why
- **Prod naming:** Enforce a single `YYYY-MM` scheme to avoid duplicate runs and simplify prod executions (no need to pass `run_name`).
- **EnsureRunName Lambda:** Step Functions can’t do string formatting or conditional logic in-place, so a Lambda normalizes `run_name` for prod (YYYY-MM), custom (required), and test (default `"test"`).
- **S3 docs:** Previous docs showed `data/` and `runs/{run_id}/`, but the code uses `prod/{YYYY-MM}/`, `custom/{run_name}/`, and `test/` via `build_run_base`. Docs are now aligned with the implementation.
- **max_concurrency:** Default 10 improves Map throughput; value remains configurable via execution input.

## How
- Added `handlers/ensure_run_name.py` (Lambda) that receives execution input, sets `run_name` by run type, and returns the normalized payload.
- Step Function: StartAt EnsureRunName (Task) → Federations; removed Choice and AddDefaultRunName Pass.
- Updated `template.yaml` with EnsureRunNameFunction and prepare_functions.sh.
- Rewrote S3 layout in infra README to reflect federations/, player_lists/, prod/, custom/, test/.
- Added “AWS Step Function” section to main README and “Run the pipeline” section to infra README.

## Testing
- `pytest tests/test_step_function.py` – ASL validation passes.
- `test_lambda_imports` – includes EnsureRunNameFunction.
- CI deploy workflow – EnsureRunNameFunctionArn added to substitution list.

## Notes / Follow-ups
- Prod input example: `{"year": 2025, "month": 3, "run_type": "prod"}`.