### PR TITLE
feat(pipeline): Add descriptive chunk filenames, backfill script, sample outputs, and resilience

### DIFF
--- a/exploratory/measure_details_raw_size.py
+++ b/exploratory/measure_details_raw_size.py
@@ -4,7 +4,7 @@ Measure raw HTML response sizes from FIDE tournament details API.
 
 Fetches a sample of tournament IDs, reports uncompressed + gzip sizes.
 Run from repo root, e.g.:
-  python exploratory/measure_details_raw_size.py data/test/data/tournament_id_chunks/chunk_0.txt --limit 20
+  python exploratory/measure_details_raw_size.py data/test/data/tournament_id_chunks/ids_chunk_0.txt --limit 20
 """
 import argparse
 import gzip

--- a/exploratory/measure_reports_raw_size.py
+++ b/exploratory/measure_reports_raw_size.py
@@ -4,7 +4,7 @@ Measure raw HTML response sizes from FIDE tournament reports API.
 
 Fetches a sample of tournament codes, reports uncompressed + gzip sizes.
 Run from repo root, e.g.:
-  python exploratory/measure_reports_raw_size.py data/test/data/tournament_id_chunks/chunk_0.txt --limit 20
+  python exploratory/measure_reports_raw_size.py data/test/data/tournament_id_chunks/ids_chunk_0.txt --limit 20
 """
 import argparse
 import gzip

--- a/handlers/README.md
+++ b/handlers/README.md
@@ -53,14 +53,14 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
   "run_type": "custom",
   "run_name": "2024-01",
   "bucket": "fide-glicko",
-  "chunk_size": 225,
+  "chunk_size": 300,
   "override": false
 }
 ```
 - **run_type**, **run_name**: Used to locate `{base}/data/tournament_ids.txt`. No year/month
   required — paths derive from run folder.
 - **ids_uri**: Optional. Defaults to `{base}/data/tournament_ids.txt`
-- **chunk_size**: default 225
+- **chunk_size**: default 300
 - **chunk_count**: Optional override
 - Returns: `chunks: [{ input_path, output_path, tournament_count, chunk_index }, ...]`
 
@@ -74,9 +74,9 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
   "override": false
 }
 ```
-- **chunk_index**: Required (0-based). Paths inferred: `{base}/data/tournament_id_chunks/chunk_{i}.txt` → `{base}/data/tournament_details_chunks/chunk_{i}`
+- **chunk_index**: Required (0-based). Paths: `{base}/data/tournament_id_chunks/ids_chunk_{i}.txt` → `{base}/data/tournament_details_chunks/details_chunk_{i}.parquet`
 - **override**: If true, overwrite existing output (default: false)
-- **save_raw**: If true, save concatenated raw HTML to `{base}/raw/details/chunk_{i}.html.gz` (default: false, ~2 MB gzipped per chunk)
+- **save_raw**: If true, save raw HTML to `{base}/raw/details/details_chunk_{i}.html.gz` (default: false)
 - Orchestrator: use `chunk_index` from each split_ids chunk, pass run_type/run_name from state
 
 ### reports_chunk
@@ -90,11 +90,11 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
   "save_raw": false
 }
 ```
-- **chunk_index**: Required (0-based). Paths inferred: `{base}/data/tournament_id_chunks/chunk_{i}.txt` → `{base}/data/tournament_reports_chunks/chunk_{i}`
+- **chunk_index**: Required (0-based). Paths: `{base}/data/tournament_id_chunks/ids_chunk_{i}.txt` → `{base}/data/tournament_reports_chunks/reports_chunk_{i}_*.parquet`
 - **override**: If true, overwrite existing output (default: false)
-- **save_raw**: If true, save concatenated raw HTML to `{base}/raw/reports/chunk_{i}.html.gz` (default: false, ~3.4 MB gzipped per chunk)
-- **details_path**: Optional. Defaults to `{base}/data/tournament_details_chunks/chunk_{i}.parquet` for date inference
-- Outputs: `{base}/data/tournament_reports_chunks/chunk_{i}_players.parquet`, `chunk_{i}_games.parquet`
+- **save_raw**: If true, save raw HTML to `{base}/raw/reports/reports_chunk_{i}.html.gz` (default: false)
+- **details_path**: Optional. Defaults to `{base}/data/tournament_details_chunks/details_chunk_{i}.parquet`
+- Outputs: `reports_chunk_{i}_players.parquet`, `reports_chunk_{i}_games.parquet`; `reports_chunk_{i}_verbose_sample.json`, `reports_chunk_{i}_games_sample.csv`
 - Orchestrator: use `chunk_index` from each split_ids chunk, pass run_type/run_name from state
 
 ### merge_chunks
@@ -109,7 +109,7 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
 - **run_type**, **run_name**: Required (as above). Locates chunk prefixes.
 - **bucket**: default fide-glicko
 - **override**: If true, overwrite existing merged files (default: false)
-- Inputs: `{base}/data/tournament_details_chunks/chunk_*.parquet`, `{base}/data/tournament_reports_chunks/chunk_*_players.parquet`, `chunk_*_games.parquet`
+- Inputs: `{base}/data/tournament_details_chunks/details_chunk_*.parquet`, `{base}/data/tournament_reports_chunks/reports_chunk_*_players.parquet`, `reports_chunk_*_games.parquet`
 - Outputs: `{base}/data/tournament_details.parquet`, `{base}/data/tournament_reports_players.parquet`, `{base}/data/tournament_reports_games.parquet`
 - Returns: `details_uri`, `reports_players_uri`, `reports_games_uri`, `details_chunks`, `reports_chunks`
 

--- a/handlers/details_chunk.py
+++ b/handlers/details_chunk.py
@@ -8,17 +8,15 @@ Event shape:
     "chunk_index": 0,
     "bucket": "fide-glicko",
     "override": false,
-    "save_raw": false
+    "save_raw": true
 }
 
 - run_type: prod | custom | test (default: custom)
 - run_name: Required for prod/custom. Ignored for test.
-- chunk_index: Chunk index (0-based). Paths inferred as
-  {base}/data/tournament_id_chunks/chunk_{i}.txt and
-  {base}/data/tournament_details_chunks/chunk_{i}.
+- chunk_index: Chunk index (0-based). Paths: ids_chunk_{i}.txt, details_chunk_{i}.parquet
 - bucket: S3 bucket (default: fide-glicko)
 - override: If true, overwrite existing output (default: false)
-- save_raw: If true, save concatenated raw HTML to raw/details/chunk_{i}.html.gz (default: false)
+- save_raw: If true, save raw HTML to raw/details/details_chunk_{i}.html.gz (default: true)
 """
 
 import logging
@@ -33,7 +31,7 @@ logger = logging.getLogger(__name__)
 def _derive_sample_and_reports_paths(output_path: str) -> tuple[str | None, str | None]:
     """
     Derive output_sample_path and output_reports_base from output_path.
-    output_path should contain /data/ (e.g. .../data/tournament_details_chunks/chunk_0).
+    output_path should contain /data/ (e.g. .../data/tournament_details_chunks/details_chunk_0).
     Returns (sample_path, reports_base) or (None, None) if /data/ not present.
     """
     if "/data/" not in output_path:
@@ -52,7 +50,7 @@ def lambda_handler(event: dict, context) -> dict:
     chunk_index = event.get("chunk_index")
     bucket = event.get("bucket", "fide-glicko")
     override = event.get("override", False)
-    save_raw = event.get("save_raw", False)
+    save_raw = event.get("save_raw", True)
 
     if run_type not in ("prod", "custom", "test"):
         return {
@@ -79,7 +77,7 @@ def lambda_handler(event: dict, context) -> dict:
         run_name,
         "data",
         "tournament_id_chunks",
-        f"chunk_{chunk_index}.txt",
+        f"ids_chunk_{chunk_index}.txt",
     )
     output_path = build_s3_uri_for_run(
         bucket,
@@ -87,7 +85,7 @@ def lambda_handler(event: dict, context) -> dict:
         run_name,
         "data",
         "tournament_details_chunks",
-        f"chunk_{chunk_index}",
+        f"details_chunk_{chunk_index}",
     )
 
     output_sample_path, output_reports_base = _derive_sample_and_reports_paths(

--- a/handlers/ensure_run_name.py
+++ b/handlers/ensure_run_name.py
@@ -13,7 +13,8 @@ Event shape (passthrough from execution input):
     "run_name": null,
     "bucket": "fide-glicko",
     "override": false,
-    "max_concurrency": 5
+    "max_concurrency": 10,
+    "chunk_size": 300
 }
 
 Returns the same input with run_name set. Fails with 400 if validation fails.
@@ -49,4 +50,5 @@ def lambda_handler(event: dict, context) -> dict:
     # Apply defaults for optional fields
     out.setdefault("bucket", "fide-glicko")
     out.setdefault("override", False)
+    out.setdefault("chunk_size", 300)
     return out

--- a/handlers/merge_chunks.py
+++ b/handlers/merge_chunks.py
@@ -14,8 +14,8 @@ Event shape:
 - bucket: S3 bucket (default: fide-glicko)
 - override: If true, overwrite existing merged files (default: false)
 
-Inputs: {base}/data/tournament_details_chunks/chunk_*.parquet,
-        {base}/data/tournament_reports_chunks/chunk_*_players.parquet, chunk_*_games.parquet
+Inputs: {base}/data/tournament_details_chunks/details_chunk_*.parquet,
+        {base}/data/tournament_reports_chunks/reports_chunk_*_players.parquet, reports_chunk_*_games.parquet
 Outputs: {base}/data/tournament_details.parquet,
          {base}/data/tournament_reports_players.parquet,
          {base}/data/tournament_reports_games.parquet

--- a/handlers/reports_chunk.py
+++ b/handlers/reports_chunk.py
@@ -8,19 +8,19 @@ Event shape:
     "chunk_index": 0,
     "bucket": "fide-glicko",
     "override": false,
-    "save_raw": false,
+    "save_raw": true,
     "details_path": null
 }
 
 - run_type: prod | custom | test (default: custom)
 - run_name: Required for prod/custom. Ignored for test.
-- chunk_index: Chunk index (0-based). Paths inferred as
-  {base}/data/tournament_id_chunks/chunk_{i}.txt and
-  {base}/data/tournament_reports_chunks/chunk_{i}.
+- chunk_index: Chunk index (0-based). Paths: ids_chunk_{i}.txt, reports_chunk_{i}_*.parquet
 - bucket: S3 bucket (default: fide-glicko)
 - override: If true, overwrite existing output (default: false)
-- save_raw: If true, save concatenated raw HTML to raw/reports/chunk_{i}.html.gz (default: false)
+- save_raw: If true, save raw HTML to raw/reports/reports_chunk_{i}.html.gz (default: true)
 - details_path: Optional S3 URI to details chunk parquet for date inference.
+
+Outputs: parquet, plus reports_chunk_{i}_verbose_sample.json and reports_chunk_{i}_games_sample.csv.
 """
 
 import logging
@@ -32,6 +32,14 @@ from get_tournament_reports import run
 logger = logging.getLogger(__name__)
 
 
+def _derive_sample_paths(output_path: str) -> tuple[str, str]:
+    """Derive sample JSON and CSV paths from output_path (data/ -> sample/)."""
+    if "/data/" not in output_path:
+        return "", ""
+    sample_base = output_path.replace("/data/", "/sample/", 1)
+    return sample_base + "_verbose_sample.json", sample_base + "_games_sample.csv"
+
+
 def lambda_handler(event: dict, context) -> dict:
     """Lambda entry point for tournament reports chunk scraper."""
     configure()
@@ -40,7 +48,7 @@ def lambda_handler(event: dict, context) -> dict:
     chunk_index = event.get("chunk_index")
     bucket = event.get("bucket", "fide-glicko")
     override = event.get("override", False)
-    save_raw = event.get("save_raw", False)
+    save_raw = event.get("save_raw", True)
     details_path = event.get("details_path")
 
     if run_type not in ("prod", "custom", "test"):
@@ -68,7 +76,7 @@ def lambda_handler(event: dict, context) -> dict:
         run_name,
         "data",
         "tournament_id_chunks",
-        f"chunk_{chunk_index}.txt",
+        f"ids_chunk_{chunk_index}.txt",
     )
     output_path = build_s3_uri_for_run(
         bucket,
@@ -76,8 +84,10 @@ def lambda_handler(event: dict, context) -> dict:
         run_name,
         "data",
         "tournament_reports_chunks",
-        f"chunk_{chunk_index}",
+        f"reports_chunk_{chunk_index}",
     )
+
+    output_sample_json, output_sample_csv = _derive_sample_paths(output_path)
 
     games_uri = output_path + "_games.parquet"
     if not override and output_exists(games_uri):
@@ -95,7 +105,7 @@ def lambda_handler(event: dict, context) -> dict:
             run_name,
             "data",
             "tournament_details_chunks",
-            f"chunk_{chunk_index}.parquet",
+            f"details_chunk_{chunk_index}.parquet",
         )
 
     logger.info(
@@ -112,6 +122,8 @@ def lambda_handler(event: dict, context) -> dict:
         max_retries=3,
         quiet=False,
         save_raw=save_raw,
+        output_sample_json=output_sample_json,
+        output_sample_csv=output_sample_csv,
     )
 
     if exit_code != 0:

--- a/handlers/split_ids.py
+++ b/handlers/split_ids.py
@@ -7,7 +7,7 @@ Event shape:
     "run_name": "2024-01",
     "bucket": "fide-glicko",
     "ids_uri": null,
-    "chunk_size": 225,
+    "chunk_size": 300,
     "override": false
 }
 
@@ -17,7 +17,7 @@ Event shape:
 - bucket: S3 bucket (default: fide-glicko).
 - ids_uri: Path to tournament IDs file. If not set, uses {base}/data/tournament_ids.txt.
   Must exist; Step Function runs tournaments Lambda first.
-- chunk_size: Max tournaments per chunk (default: 225).
+- chunk_size: Max tournaments per chunk (default: 300).
 - override: Overwrite existing chunk files (default: false).
 
 Returns: { statusCode, success, chunks: [{ input_path, output_path, tournament_count, chunk_index }, ...] }
@@ -45,7 +45,7 @@ def lambda_handler(event: dict, context) -> dict:
     bucket = event.get("bucket", "fide-glicko")
     ids_uri = event.get("ids_uri")
     chunk_count = event.get("chunk_count")
-    chunk_size = event.get("chunk_size", 225)
+    chunk_size = event.get("chunk_size", 300)
     override = event.get("override", False)
 
     if run_type not in ("prod", "custom", "test"):

--- a/infra/README.md
+++ b/infra/README.md
@@ -100,12 +100,12 @@ s3://fide-glicko/
 │       ├── data/
 │       │   ├── tournament_ids.txt
 │       │   ├── tournament_id_chunks/
-│       │   │   └── chunk_{N}.txt
+│       │   │   └── ids_chunk_{N}.txt
 │       │   ├── tournament_details_chunks/
-│       │   │   └── chunk_{N}.parquet
+│       │   │   └── details_chunk_{N}.parquet
 │       │   ├── tournament_reports_chunks/
-│       │   │   ├── chunk_{N}_players.parquet
-│       │   │   └── chunk_{N}_games.parquet
+│       │   │   ├── reports_chunk_{N}_players.parquet
+│       │   │   └── reports_chunk_{N}_games.parquet
 │       │   ├── tournament_details.parquet
 │       │   ├── tournament_reports_players.parquet
 │       │   └── tournament_reports_games.parquet

--- a/infra/step-function/README.md
+++ b/infra/step-function/README.md
@@ -66,7 +66,7 @@ aws stepfunctions start-execution \
 - **bucket** – S3 bucket (default: fide-glicko)
 - **override** – if true, refetch/overwrite even when cached (default: false)
 - **max_concurrency** – Map state parallelism for chunk processing (default: 10)
-- **chunk_size** – optional; Lambda default is 225
+- **chunk_size** – optional; default 300
 
 ## Check status
 
@@ -84,3 +84,7 @@ aws stepfunctions get-execution-history --execution-arn EXECUTION_ARN
 - Merge + Validate: ~2 min
 
 **Total: ~25–35 min**
+
+## Troubleshooting
+
+**ReportsChunk Lambda timeouts** – Each invocation has a 15 min max (Lambda limit). If a chunk times out (or Lambda.SdkClientException/Lambda.Unknown), the Map iterator retries it once (transient issues). Check CloudWatch Logs for `Slow report fetch`, `timeout`, `connection error` to diagnose anomalous chunks. For persistently slow months, re-run with smaller `chunk_size` (e.g. `150`).

--- a/infra/step-function/pipeline.asl.json
+++ b/infra/step-function/pipeline.asl.json
@@ -87,7 +87,8 @@
                 "run_type.$": "$.run_type",
                 "run_name.$": "$.run_name",
                 "bucket.$": "$.bucket",
-                "override.$": "$.override"
+                "override.$": "$.override",
+                "chunk_size.$": "$.chunk_size"
               },
               "End": true
             }
@@ -211,6 +212,16 @@
                 "IntervalSeconds": 5,
                 "MaxAttempts": 3,
                 "BackoffRate": 2
+              },
+              {
+                "ErrorEquals": [
+                  "Lambda.ClientExecutionTimeoutException",
+                  "Lambda.SdkClientException",
+                  "Lambda.Unknown"
+                ],
+                "IntervalSeconds": 30,
+                "MaxAttempts": 1,
+                "BackoffRate": 2
               }
             ],
             "Catch": [
@@ -231,7 +242,7 @@
               "chunk_index.$": "$.chunk_index",
               "bucket.$": "$.bucket",
               "override.$": "$.override",
-              "save_raw": false
+              "save_raw": true
             },
             "Retry": [
               {
@@ -244,6 +255,16 @@
                 "ErrorEquals": ["Lambda.ServiceException"],
                 "IntervalSeconds": 5,
                 "MaxAttempts": 3,
+                "BackoffRate": 2
+              },
+              {
+                "ErrorEquals": [
+                  "Lambda.ClientExecutionTimeoutException",
+                  "Lambda.SdkClientException",
+                  "Lambda.Unknown"
+                ],
+                "IntervalSeconds": 30,
+                "MaxAttempts": 1,
                 "BackoffRate": 2
               }
             ],

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,39 @@
 
 Production automation for the FIDE data pipeline.
 
+## run_prod_backfill.py
+
+Run the AWS Step Function pipeline for a range of prod months with controlled concurrency.
+Starts executions, polls status, and starts new ones when slots open. Logs progress and
+time estimates.
+
+### Usage
+
+```bash
+# Backfill Jan 2024 through Dec 2024 (one at a time)
+uv run scripts/run_prod_backfill.py --start 2024-01 --end 2024-12
+
+# Run 2 months concurrently
+uv run scripts/run_prod_backfill.py --start 2024-01 --end 2024-06 -c 2
+
+# Dry run to see which months would run
+uv run scripts/run_prod_backfill.py --start 2024-01 --end 2024-03 --dry-run
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--start`, `--end` | Required. Month range as YYYY-MM (e.g. 2024-01). |
+| `--concurrency`, `-c` | Max concurrent Step Function executions (default: 1). |
+| `--state-machine-arn` | Override auto-discovery of fide-glicko-pipeline. |
+| `--region` | AWS region. |
+| `--bucket` | S3 bucket (default: fide-glicko). |
+| `--override` | Pass override=true to pipeline. |
+| `--max-concurrency` | Map concurrency per execution (default: 10). |
+| `--chunk-size` | Max tournaments per chunk (default: 300). |
+| `--dry-run` | List months without starting. |
+
 ## run_full_pipeline.py
 
 The main pipeline script. Fetches all FIDE data needed for a given month and optionally validates consistency.
@@ -40,7 +73,7 @@ uv run scripts/run_full_pipeline.py --year 2025 --month 12
 |--------|-------------|
 | `--year`, `--month` | Required. Target month (e.g. `--year 2024 --month 1`). |
 | `--data-dir` | Base data directory (default: `data`). |
-| `--test` | Quick smoke run: limit to 5 tournaments, 5 details, 5 reports; skip JSON/CSV samples. |
+| `--test` | Quick smoke run: limit to 5 tournaments, 5 details, 5 reports. |
 | `--limit N` | Limit tournaments/details/reports to N each (overrides `--test` defaults when set). |
 | `--skip-federations` | Use existing `data/federations.csv` instead of fetching. |
 | `--skip-player-list` | Use existing `src/data/players_list.parquet` instead of downloading. |
@@ -55,7 +88,7 @@ uv run scripts/run_full_pipeline.py --year 2025 --month 12
 # Full run for January 2024
 uv run scripts/run_full_pipeline.py --year 2024 --month 1
 
-# Quick test (5 tournaments per step, no samples)
+# Quick test (5 tournaments per step)
 uv run scripts/run_full_pipeline.py --year 2024 --month 1 --test
 
 # Reuse existing federations and player list

--- a/scripts/run_full_pipeline.py
+++ b/scripts/run_full_pipeline.py
@@ -85,7 +85,7 @@ def main() -> int:
     parser.add_argument(
         "--test",
         action="store_true",
-        help="Test run with limited sampling: limit tournaments/details/reports to %d each, skip JSON/CSV samples"
+        help="Test run with limited sampling: limit tournaments/details/reports to %d each"
         % TEST_LIMIT_REPORTS,
     )
     parser.add_argument(
@@ -246,8 +246,6 @@ def main() -> int:
     ]
     if limit_reports > 0:
         reports_cmd.extend(["--limit", str(limit_reports)])
-    if args.test:
-        reports_cmd.append("--no-samples")
     if args.no_validation:
         reports_cmd.append("--no-validation")
     if not run(reports_cmd, base_dir, "STEP 5: Get tournament reports (games)"):

--- a/scripts/run_prod_backfill.py
+++ b/scripts/run_prod_backfill.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+Run FIDE pipeline Step Function for multiple prod months with controlled concurrency.
+
+Starts executions for each month in [start, end], limiting concurrent runs.
+Polls status and starts new executions when slots open. Logs progress and
+time estimates.
+
+Example:
+  uv run scripts/run_prod_backfill.py --start 2024-01 --end 2024-12
+  uv run scripts/run_prod_backfill.py --start 2024-01 --end 2024-06 --concurrency 2
+
+Requires AWS credentials (e.g. aws configure). Uses default region unless --region.
+"""
+
+import argparse
+import json
+import logging
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterator
+
+import boto3
+from botocore.exceptions import ClientError
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+# Per infra/step-function/README.md
+AVG_RUN_MINUTES = 30
+POLL_INTERVAL_SEC = 60
+STATE_MACHINE_NAME = "fide-glicko-pipeline"
+
+
+def parse_month(s: str) -> tuple[int, int]:
+    """Parse YYYY-MM to (year, month)."""
+    try:
+        parts = s.split("-")
+        if len(parts) != 2:
+            raise ValueError()
+        year, month = int(parts[0]), int(parts[1])
+        if not (1 <= month <= 12):
+            raise ValueError("month must be 1-12")
+        return year, month
+    except (ValueError, IndexError) as e:
+        raise argparse.ArgumentTypeError(
+            f"Invalid month '{s}': expected YYYY-MM (e.g. 2024-01)"
+        ) from e
+
+
+def month_range(
+    start: tuple[int, int], end: tuple[int, int]
+) -> Iterator[tuple[int, int]]:
+    """Yield (year, month) for each month from start (incl) to end (incl)."""
+    sy, sm = start
+    ey, em = end
+    if (sy, sm) > (ey, em):
+        raise ValueError("start month must be <= end month")
+    y, m = sy, sm
+    while (y, m) <= (ey, em):
+        yield y, m
+        m += 1
+        if m > 12:
+            m = 1
+            y += 1
+
+
+@dataclass
+class RunState:
+    execution_arn: str
+    year: int
+    month: int
+    started_at: datetime
+    status: str = "RUNNING"
+
+
+def get_state_machine_arn(client, name: str) -> str | None:
+    """Find state machine ARN by name."""
+    paginator = client.get_paginator("list_state_machines")
+    for page in paginator.paginate():
+        for sm in page.get("stateMachines", []):
+            if sm.get("name") == name:
+                return sm["stateMachineArn"]
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run prod pipeline for a range of months with controlled concurrency",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--start",
+        type=parse_month,
+        required=True,
+        metavar="YYYY-MM",
+        help="Start month (e.g. 2024-01)",
+    )
+    parser.add_argument(
+        "--end",
+        type=parse_month,
+        required=True,
+        metavar="YYYY-MM",
+        help="End month (e.g. 2024-12)",
+    )
+    parser.add_argument(
+        "--concurrency",
+        "-c",
+        type=int,
+        default=1,
+        help="Max concurrent Step Function executions (default: 1)",
+    )
+    parser.add_argument(
+        "--state-machine-arn",
+        help="Step Function state machine ARN (default: lookup fide-glicko-pipeline)",
+    )
+    parser.add_argument(
+        "--region",
+        default=None,
+        help="AWS region (default: from config)",
+    )
+    parser.add_argument(
+        "--bucket",
+        default="fide-glicko",
+        help="S3 bucket (default: fide-glicko)",
+    )
+    parser.add_argument(
+        "--override",
+        action="store_true",
+        help="Pass override=true to pipeline (refetch/overwrite cached)",
+    )
+    parser.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=10,
+        help="Map state concurrency per execution (default: 10)",
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=None,
+        help="Max tournaments per chunk (default: 300; use smaller if reports_chunk times out)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print months that would run, do not start",
+    )
+    args = parser.parse_args()
+
+    if args.concurrency < 1:
+        logger.error("--concurrency must be >= 1")
+        return 1
+
+    try:
+        months = list(month_range(args.start, args.end))
+    except ValueError as e:
+        logger.error("%s", e)
+        return 1
+    if not months:
+        logger.error("No months in range")
+        return 1
+
+    logger.info(
+        "Backfill %d months from %04d-%02d to %04d-%02d (concurrency=%d)",
+        len(months),
+        *args.start,
+        *args.end,
+        args.concurrency,
+    )
+
+    if args.dry_run:
+        for y, m in months:
+            logger.info("  Would run: %04d-%02d", y, m)
+        return 0
+
+    client = boto3.client("stepfunctions", region_name=args.region or None)
+    arn = args.state_machine_arn or get_state_machine_arn(client, STATE_MACHINE_NAME)
+    if not arn:
+        logger.error(
+            "State machine %r not found. Deploy the stack or pass --state-machine-arn",
+            STATE_MACHINE_NAME,
+        )
+        return 1
+
+    pending: list[tuple[int, int]] = list(months)
+    running: dict[str, RunState] = {}
+    completed: list[tuple[int, int, str, str]] = []  # (y, m, status, execution_arn)
+    failed: list[tuple[int, int, str, str]] = []
+    total = len(months)
+
+    def start_next() -> bool:
+        if not pending or len(running) >= args.concurrency:
+            return False
+        y, m = pending.pop(0)
+        name = f"backfill-{y:04d}-{m:02d}-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
+        input_dict = {
+            "year": y,
+            "month": m,
+            "run_type": "prod",
+            "bucket": args.bucket,
+            "override": args.override,
+            "max_concurrency": args.max_concurrency,
+        }
+        if args.chunk_size is not None:
+            input_dict["chunk_size"] = args.chunk_size
+        try:
+            resp = client.start_execution(
+                stateMachineArn=arn,
+                name=name,
+                input=json.dumps(input_dict),
+            )
+            exec_arn = resp["executionArn"]
+            running[exec_arn] = RunState(
+                execution_arn=exec_arn,
+                year=y,
+                month=m,
+                started_at=datetime.now(timezone.utc),
+                status="RUNNING",
+            )
+            logger.info("Started %04d-%02d -> %s", y, m, exec_arn.split(":")[-1])
+            return True
+        except ClientError as e:
+            logger.error("Failed to start %04d-%02d: %s", y, m, e)
+            failed.append((y, m, str(e), ""))
+            return True  # try next
+
+    def poll_running() -> None:
+        done = []
+        for exec_arn, state in list(running.items()):
+            try:
+                desc = client.describe_execution(executionArn=exec_arn)
+                status = desc["status"]
+                if status in ("SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"):
+                    done.append(exec_arn)
+                    elapsed = (
+                        datetime.now(timezone.utc) - state.started_at
+                    ).total_seconds()
+                    if status == "SUCCEEDED":
+                        completed.append((state.year, state.month, status, exec_arn))
+                        logger.info(
+                            "Completed %04d-%02d (%.1f min) -> %s",
+                            state.year,
+                            state.month,
+                            elapsed / 60,
+                            status,
+                        )
+                    else:
+                        failed.append((state.year, state.month, status, exec_arn))
+                        logger.warning(
+                            "Failed %04d-%02d: %s",
+                            state.year,
+                            state.month,
+                            status,
+                        )
+            except ClientError as e:
+                logger.warning("Poll failed for %s: %s", exec_arn, e)
+        for arn in done:
+            del running[arn]
+
+    # Start initial batch
+    while start_next():
+        pass
+
+    while running or pending:
+        poll_running()
+        # Start more if we have capacity
+        while start_next():
+            pass
+
+        if running or pending:
+            n_done = len(completed) + len(failed)
+            # Rough estimate: remaining runs = pending + running; each ~30 min
+            remaining_runs = len(pending) + len(running)
+            # Serialized time for remaining at current concurrency
+            est_min = (remaining_runs * AVG_RUN_MINUTES) / args.concurrency
+            logger.info(
+                "Progress: %d/%d done | %d running | %d pending | est. %.0f min remaining",
+                n_done,
+                total,
+                len(running),
+                len(pending),
+                est_min,
+            )
+            if running:
+                for s in running.values():
+                    logger.info(
+                        "  - %04d-%02d running (%s)",
+                        s.year,
+                        s.month,
+                        s.execution_arn.split(":")[-1],
+                    )
+            time.sleep(POLL_INTERVAL_SEC)
+
+    # Final summary
+    logger.info("")
+    logger.info("=" * 60)
+    logger.info(
+        "Backfill complete: %d succeeded, %d failed", len(completed), len(failed)
+    )
+    for y, m, status, _ in completed:
+        logger.info("  SUCCESS %04d-%02d", y, m)
+    for y, m, status, exec_arn in failed:
+        logger.warning("  FAILED  %04d-%02d %s %s", y, m, status, exec_arn or "")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scraper/get_tournament_details.py
+++ b/src/scraper/get_tournament_details.py
@@ -259,6 +259,11 @@ def fetch_tournament_details(
             delay = 0.1 * (
                 2 ** (attempt - 1)
             )  # Exponential backoff: 100ms, 200ms, 400ms
+            logger.info(
+                "Retrying details fetch: tournament_id=%s attempt=%d",
+                tournament_id,
+                attempt + 1,
+            )
             time.sleep(delay)
 
         try:
@@ -275,9 +280,22 @@ def fetch_tournament_details(
             finally:
                 elapsed = time.perf_counter() - t0
                 attempt_times.append(elapsed)
+                if elapsed > 10:
+                    logger.warning(
+                        "Slow details fetch: tournament_id=%s took %.1fs (attempt %d)",
+                        tournament_id,
+                        elapsed,
+                        attempt + 1,
+                    )
 
             if response.status_code != 200:
                 last_error = f"HTTP {response.status_code}"
+                logger.warning(
+                    "HTTP error: tournament_id=%s status=%s (attempt %d)",
+                    tournament_id,
+                    response.status_code,
+                    attempt + 1,
+                )
                 if _attempt_log is not None:
                     _attempt_log.append(
                         {
@@ -342,6 +360,12 @@ def fetch_tournament_details(
 
         except requests.exceptions.Timeout as e:
             last_error = f"timeout: {e}"
+            logger.warning(
+                "Details fetch timeout: tournament_id=%s (attempt %d): %s",
+                tournament_id,
+                attempt + 1,
+                e,
+            )
             if _attempt_log is not None:
                 _attempt_log.append(
                     {
@@ -367,6 +391,12 @@ def fetch_tournament_details(
                 ]
             ):
                 last_error = f"network error: {e}"
+                logger.warning(
+                    "Details fetch connection error: tournament_id=%s (attempt %d): %s",
+                    tournament_id,
+                    attempt + 1,
+                    e,
+                )
                 if _attempt_log is not None:
                     _attempt_log.append(
                         {
@@ -378,6 +408,11 @@ def fetch_tournament_details(
                     )
                 continue
             last_error = f"connection error: {e}"
+            logger.warning(
+                "Details fetch connection error (non-retryable): tournament_id=%s: %s",
+                tournament_id,
+                e,
+            )
             return None, last_error, len(attempt_times), None
         except requests.exceptions.RequestException as e:
             error_str = str(e).lower()
@@ -394,6 +429,12 @@ def fetch_tournament_details(
                 ]
             ):
                 last_error = f"network error: {e}"
+                logger.warning(
+                    "Details fetch RequestException: tournament_id=%s (attempt %d): %s",
+                    tournament_id,
+                    attempt + 1,
+                    e,
+                )
                 if _attempt_log is not None:
                     _attempt_log.append(
                         {
@@ -405,9 +446,20 @@ def fetch_tournament_details(
                     )
                 continue
             last_error = f"network error: {e}"
+            logger.warning(
+                "Details fetch RequestException (non-retryable): tournament_id=%s: %s",
+                tournament_id,
+                e,
+            )
             return None, last_error, len(attempt_times), None
         except Exception as e:
             last_error = f"parse error: {e}"
+            logger.warning(
+                "Details fetch error: tournament_id=%s (attempt %d): %s",
+                tournament_id,
+                attempt + 1,
+                e,
+            )
             if _attempt_log is not None:
                 _attempt_log.append(
                     {
@@ -765,7 +817,7 @@ def run(
     limit: int = 0,
     output_sample_path: str | None = None,
     output_reports_base: str | None = None,
-    save_raw: bool = False,
+    save_raw: bool = True,
 ) -> int:
     """
     Scrape tournament details for IDs from input_path, write to output_path.
@@ -875,6 +927,11 @@ def run(
 
             result = {"tournament_id": tournament_id}
             if details is None:
+                logger.warning(
+                    "Details fetch failed: tournament_id=%s error=%s",
+                    tournament_id,
+                    error or "unknown",
+                )
                 error_count += 1
                 result["success"] = False
                 result["error"] = error or "fetch failed"

--- a/src/scraper/get_tournament_reports.py
+++ b/src/scraper/get_tournament_reports.py
@@ -456,6 +456,11 @@ def fetch_tournament_report(
             delay = 0.1 * (
                 2 ** (attempt - 1)
             )  # Exponential backoff: 100ms, 200ms, 400ms
+            logger.info(
+                "Retrying report fetch: tournament_code=%s attempt=%d",
+                tournament_code,
+                attempt + 1,
+            )
             time.sleep(delay)
 
         try:
@@ -473,9 +478,22 @@ def fetch_tournament_report(
             finally:
                 elapsed = time.perf_counter() - t0
                 attempt_times.append(elapsed)
+                if elapsed > 10:
+                    logger.warning(
+                        "Slow report fetch: tournament_code=%s took %.1fs (attempt %d)",
+                        tournament_code,
+                        elapsed,
+                        attempt + 1,
+                    )
 
             if response.status_code != 200:
                 last_error = f"HTTP {response.status_code}"
+                logger.warning(
+                    "HTTP error: tournament_code=%s status=%s (attempt %d)",
+                    tournament_code,
+                    response.status_code,
+                    attempt + 1,
+                )
                 if _attempt_log is not None:
                     _attempt_log.append(
                         {
@@ -644,6 +662,12 @@ def fetch_tournament_report(
 
         except requests.exceptions.Timeout as e:
             last_error = f"timeout: {e}"
+            logger.warning(
+                "Report fetch timeout: tournament_code=%s (attempt %d): %s",
+                tournament_code,
+                attempt + 1,
+                e,
+            )
             if _attempt_log is not None:
                 _attempt_log.append(
                     {
@@ -669,6 +693,12 @@ def fetch_tournament_report(
                 ]
             ):
                 last_error = f"network error: {e}"
+                logger.warning(
+                    "Report fetch connection error: tournament_code=%s (attempt %d): %s",
+                    tournament_code,
+                    attempt + 1,
+                    e,
+                )
                 if _attempt_log is not None:
                     _attempt_log.append(
                         {
@@ -680,6 +710,11 @@ def fetch_tournament_report(
                     )
                 continue
             last_error = f"connection error: {e}"
+            logger.warning(
+                "Report fetch connection error (non-retryable): tournament_code=%s: %s",
+                tournament_code,
+                e,
+            )
             return None, last_error, len(attempt_times), None
         except requests.exceptions.RequestException as e:
             error_str = str(e).lower()
@@ -696,6 +731,12 @@ def fetch_tournament_report(
                 ]
             ):
                 last_error = f"network error: {e}"
+                logger.warning(
+                    "Report fetch RequestException: tournament_code=%s (attempt %d): %s",
+                    tournament_code,
+                    attempt + 1,
+                    e,
+                )
                 if _attempt_log is not None:
                     _attempt_log.append(
                         {
@@ -707,9 +748,20 @@ def fetch_tournament_report(
                     )
                 continue
             last_error = f"network error: {e}"
+            logger.warning(
+                "Report fetch RequestException (non-retryable): tournament_code=%s: %s",
+                tournament_code,
+                e,
+            )
             return None, last_error, len(attempt_times), None
         except Exception as e:
             last_error = f"parse error: {e}"
+            logger.warning(
+                "Report fetch error: tournament_code=%s (attempt %d): %s",
+                tournament_code,
+                attempt + 1,
+                e,
+            )
             if _attempt_log is not None:
                 _attempt_log.append(
                     {
@@ -1275,7 +1327,7 @@ def save_verbose_json_sample(
     sample_size: int = 5,
     details_map: Optional[Dict[str, Tuple[Optional[str], Optional[str]]]] = None,
 ):
-    """Save a sample of raw results (tournaments with players/rounds) to JSON. Round dates are datetime (ISO when serialized)."""
+    """Save a sample of raw results (tournaments with players/rounds) to JSON. Supports local and S3 paths."""
     try:
         sample_results = [r for r in results if r.get("success")][:sample_size]
         if not sample_results:
@@ -1286,9 +1338,6 @@ def save_verbose_json_sample(
         _transform_results_round_dates_to_datetime(
             sample_results, details_map=details_map
         )
-        dirname = os.path.dirname(json_path)
-        if dirname:
-            os.makedirs(dirname, exist_ok=True)
 
         def _json_default(obj):
             if isinstance(obj, datetime):
@@ -1297,10 +1346,10 @@ def save_verbose_json_sample(
                 f"Object of type {type(obj).__name__} is not JSON serializable"
             )
 
-        with open(json_path, "w", encoding="utf-8") as f:
-            json.dump(
-                sample_results, f, indent=2, ensure_ascii=False, default=_json_default
-            )
+        content = json.dumps(
+            sample_results, indent=2, ensure_ascii=False, default=_json_default
+        )
+        _write_to_path(json_path, content)
         logger.info(f"Saved sample of {len(sample_results)} tournaments to {json_path}")
     except Exception as e:
         logger.error(f"Verbose JSON sample save failed: {e}")
@@ -1313,6 +1362,7 @@ def save_csv_sample_from_parquet(
 ):
     """
     Read parquet, sample rows, save as CSV to confirm the parquet file works.
+    Supports local and S3 paths for both input and output.
     """
     try:
         df = pd.read_parquet(parquet_path)
@@ -1321,10 +1371,8 @@ def save_csv_sample_from_parquet(
             return
         n = min(sample_size, len(df))
         sample_df = df.sample(n=n, random_state=42) if n < len(df) else df
-        csv_dir = os.path.dirname(csv_path)
-        if csv_dir:
-            os.makedirs(csv_dir, exist_ok=True)
-        sample_df.to_csv(csv_path, index=False)
+        content = sample_df.to_csv(index=False)
+        _write_to_path(csv_path, content)
         logger.info(f"Saved sample of {n} games to {csv_path} (confirms parquet)")
     except Exception as e:
         logger.error(f"CSV sample save failed: {e}")
@@ -1353,7 +1401,9 @@ def run(
     max_retries: int = 3,
     quiet: bool = False,
     limit: int = 0,
-    save_raw: bool = False,
+    save_raw: bool = True,
+    output_sample_json: Optional[str] = None,
+    output_sample_csv: Optional[str] = None,
 ) -> int:
     """
     Scrape tournament reports for codes from input_path, write to output_path.
@@ -1367,7 +1417,9 @@ def run(
         max_retries: Retry passes for failed fetches.
         quiet: Reduce log output.
         limit: Process only first N codes (0 = all).
-        save_raw: If True, save concatenated raw HTML to raw/reports/chunk_{i}.html.gz.
+        save_raw: If True, save concatenated raw HTML to raw/reports/reports_chunk_{i}.html.gz.
+        output_sample_json: Optional path for verbose JSON sample (tournaments with players/rounds).
+        output_sample_csv: Optional path for CSV sample from games parquet.
 
     Returns:
         0 on success, 1 on failure.
@@ -1479,6 +1531,11 @@ def run(
 
             result = {"tournament_code": code}
             if report is None:
+                logger.warning(
+                    "Report fetch failed: tournament_code=%s error=%s",
+                    code,
+                    error or "unknown",
+                )
                 error_count += 1
                 result["success"] = False
                 result["error"] = error or "fetch failed"
@@ -1528,6 +1585,16 @@ def run(
 
     save_players_parquet(all_results, players_path)
     save_games_parquet(all_results, games_path, details_map=details_map)
+
+    if output_sample_json:
+        save_verbose_json_sample(
+            all_results,
+            output_sample_json,
+            sample_size=100,
+            details_map=details_map,
+        )
+    if output_sample_csv:
+        save_csv_sample_from_parquet(games_path, output_sample_csv, sample_size=100)
 
     elapsed = time.time() - start_time
     logger.info(

--- a/src/scraper/merge_chunks.py
+++ b/src/scraper/merge_chunks.py
@@ -1,8 +1,8 @@
 """
 Merge tournament details and reports chunk parquets into single files.
 
-Reads from {base}/data/tournament_details_chunks/chunk_*.parquet and
-{base}/data/tournament_reports_chunks/chunk_*_players.parquet, chunk_*_games.parquet,
+Reads from {base}/data/tournament_details_chunks/details_chunk_*.parquet and
+{base}/data/tournament_reports_chunks/reports_chunk_*_players.parquet, reports_chunk_*_games.parquet,
 concatenates, and writes to {base}/data/:
   - tournament_details.parquet
   - tournament_reports_players.parquet
@@ -15,14 +15,14 @@ import re
 
 logger = logging.getLogger(__name__)
 
-# Chunk filenames: chunk_0.parquet, chunk_1.parquet, ...
-DETAILS_CHUNK_RE = re.compile(r"chunk_(\d+)\.parquet$")
-REPORTS_PLAYERS_RE = re.compile(r"chunk_(\d+)_players\.parquet$")
-REPORTS_GAMES_RE = re.compile(r"chunk_(\d+)_games\.parquet$")
+# Chunk filenames: details_chunk_0.parquet, reports_chunk_0_players.parquet, ...
+DETAILS_CHUNK_RE = re.compile(r"details_chunk_(\d+)\.parquet$")
+REPORTS_PLAYERS_RE = re.compile(r"reports_chunk_(\d+)_players\.parquet$")
+REPORTS_GAMES_RE = re.compile(r"reports_chunk_(\d+)_games\.parquet$")
 
 
 def _parse_chunk_index(key: str, pattern: re.Pattern) -> int | None:
-    """Extract chunk index from key like 'prod/2024-01/data/tournament_details_chunks/chunk_3.parquet'."""
+    """Extract chunk index from key like 'prod/2024-01/data/tournament_details_chunks/details_chunk_3.parquet'."""
     parts = key.split("/")
     if not parts:
         return None
@@ -93,7 +93,7 @@ def run(
     if not players_keys or not games_keys:
         raise RuntimeError(
             f"No reports chunks found under s3://{bucket}/{reports_prefix} "
-            "(need chunk_*_players.parquet and chunk_*_games.parquet)"
+            "(need reports_chunk_*_players.parquet and reports_chunk_*_games.parquet)"
         )
 
     details_uri = build_s3_uri_for_run(

--- a/src/scraper/split_tournament_ids.py
+++ b/src/scraper/split_tournament_ids.py
@@ -94,7 +94,7 @@ def even_split(items: List[str], n: int) -> List[List[str]]:
 def run(
     ids_path: str,
     chunk_count: Optional[int] = None,
-    chunk_size: int = 225,
+    chunk_size: int = 300,
     bucket: str = "fide-glicko",
     output_prefix: str = "data",
     chunk_prefix: str = "chunk",
@@ -108,7 +108,7 @@ def run(
     Args:
         ids_path: Path to tournament IDs file (one per line). S3 or local.
         chunk_count: Number of chunks (optional). If not set, derived from chunk_size.
-        chunk_size: Max tournaments per chunk when chunk_count not set (default: 225).
+        chunk_size: Max tournaments per chunk when chunk_count not set (default: 300).
         bucket: S3 bucket (for building chunk/output paths if using S3).
         output_prefix: S3 prefix when ids_path does not match standard structure.
         chunk_prefix: Prefix for chunk input files (unused with standard structure).
@@ -175,16 +175,21 @@ def run(
     result = []
     for i, chunk_ids in enumerate(chunks):
         chunk_content = "\n".join(chunk_ids) + "\n"
-        # New structure: tournament_id_chunks/chunk_{i}.txt, tournament_details_chunks/chunk_{i}
+        # Structure: tournament_id_chunks/ids_chunk_{i}.txt, tournament_details_chunks/details_chunk_{i}
         if _is_s3(run_base):
-            chunk_input_path = f"{run_base}/data/tournament_id_chunks/chunk_{i}.txt"
-            chunk_output_path = f"{run_base}/data/tournament_details_chunks/chunk_{i}"
+            chunk_input_path = f"{run_base}/data/tournament_id_chunks/ids_chunk_{i}.txt"
+            chunk_output_path = (
+                f"{run_base}/data/tournament_details_chunks/details_chunk_{i}"
+            )
         else:
             chunk_input_path = str(
-                Path(run_base) / "data" / "tournament_id_chunks" / f"chunk_{i}.txt"
+                Path(run_base) / "data" / "tournament_id_chunks" / f"ids_chunk_{i}.txt"
             )
             chunk_output_path = str(
-                Path(run_base) / "data" / "tournament_details_chunks" / f"chunk_{i}"
+                Path(run_base)
+                / "data"
+                / "tournament_details_chunks"
+                / f"details_chunk_{i}"
             )
 
         if not override and _output_exists(chunk_input_path):
@@ -226,8 +231,8 @@ def main() -> int:
     parser.add_argument(
         "--chunk-size",
         type=int,
-        default=225,
-        help="Max tournaments per chunk when chunk-count not set (default: 225)",
+        default=300,
+        help="Max tournaments per chunk when chunk-count not set (default: 300)",
     )
     parser.add_argument(
         "--bucket",

--- a/template.yaml
+++ b/template.yaml
@@ -106,7 +106,7 @@ Resources:
         Command:
           - handlers.reports_chunk.lambda_handler
       Timeout: 900
-      MemorySize: 1024
+      MemorySize: 2048
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref DataBucket


### PR DESCRIPTION
## What changed

- **Descriptive chunk filenames**: Renamed `chunk_{i}` → `ids_chunk_{i}.txt`, `details_chunk_{i}.parquet`, `reports_chunk_{i}_*.parquet` so downloaded files identify themselves.
- **Default outputs**: `save_raw` now defaults to true for details and reports chunks; reports chunks emit JSON and CSV samples by default (`reports_chunk_{i}_verbose_sample.json`, `reports_chunk_{i}_games_sample.csv`).
- **Chunk size**: Default increased from 225 to 300; `chunk_size` is configurable via execution input and passed through the pipeline.
- **Backfill script**: `scripts/run_prod_backfill.py` runs the Step Function for a prod month range with concurrency, polling, and progress/time estimates.
- **Scraper logging**: Added structured logging for slow fetches (>10s), timeouts, connection errors, HTTP errors, retries, and fetch failures in both details and reports scrapers.
- **Chunk retries**: One retry per chunk in the Map iterator for `Lambda.ClientExecutionTimeoutException`, `Lambda.SdkClientException`, and `Lambda.Unknown`.
- **ReportsChunk memory**: Increased from 1024 to 2048 MB.

## Why

Observed occasional reports_chunk Lambda timeouts (~46s/tournament vs normal 1–2s). To debug and mitigate:

- **Logging** instead of shrinking chunks: most chunks complete in 3–5 minutes; only some chunks are slow. Warnings like `Slow report fetch`, `timeout`, and `connection error` in CloudWatch help isolate FIDE or network issues.
- **One retry per chunk**: Transient failures (timeouts, SDK errors) often succeed on retry; 1 retry avoids full pipeline failure for a single bad chunk.
- **Descriptive filenames**: Chunks are easier to identify when inspecting artifacts without full S3 paths.
- **300 default chunk size**: Larger chunks reduce overhead; still below Lambda’s 15-minute limit for typical runs.
- **Backfill script**: Simplifies running multi-month backfills with controlled concurrency and progress output.