### PR TITLE
perf(lambda): Tune details_chunk and validate memory from CloudWatch usage

### DIFF
--- a/infra/github-deploy-policy.json
+++ b/infra/github-deploy-policy.json
@@ -69,7 +69,9 @@
         "lambda:UpdateAlias",
         "lambda:GetAlias",
         "lambda:AddPermission",
-        "lambda:RemovePermission"
+        "lambda:RemovePermission",
+        "lambda:TagResource",
+        "lambda:UntagResource"
       ],
       "Resource": "arn:aws:lambda:us-east-1:710271917035:function:fide-glicko-*"
     },

--- a/template.yaml
+++ b/template.yaml
@@ -87,7 +87,7 @@ Resources:
         Command:
           - handlers.details_chunk.lambda_handler
       Timeout: 900
-      MemorySize: 1024
+      MemorySize: 512
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref DataBucket
@@ -144,7 +144,7 @@ Resources:
         Command:
           - handlers.validate.lambda_handler
       Timeout: 300
-      MemorySize: 1024
+      MemorySize: 1536
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref DataBucket

--- a/tests/test_github_deploy_policy.py
+++ b/tests/test_github_deploy_policy.py
@@ -1,0 +1,50 @@
+"""Validate GitHub deploy policy includes permissions required for SAM/CloudFormation.
+
+Catches deploy failures from missing IAM permissions before they hit CI:
+- lambda:TagResource / lambda:UntagResource (CloudFormation tags Lambda functions)
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POLICY_PATH = REPO_ROOT / "infra" / "github-deploy-policy.json"
+
+# Actions CloudFormation/SAM needs for Lambda create/update.
+# Add here when a deploy fails with AccessDenied on a new action.
+REQUIRED_LAMBDA_ACTIONS = {
+    "lambda:CreateFunction",
+    "lambda:DeleteFunction",
+    "lambda:GetFunction",
+    "lambda:GetFunctionConfiguration",
+    "lambda:UpdateFunctionCode",
+    "lambda:UpdateFunctionConfiguration",
+    "lambda:TagResource",
+    "lambda:UntagResource",
+}
+
+
+def _load_policy() -> dict:
+    with open(POLICY_PATH) as f:
+        return json.load(f)
+
+
+def _get_lambda_statement_actions(policy: dict) -> set[str]:
+    for stmt in policy.get("Statement", []):
+        if stmt.get("Sid") == "Lambda":
+            actions = stmt.get("Action", [])
+            return set(actions) if isinstance(actions, list) else {actions}
+    return set()
+
+
+def test_github_deploy_policy_includes_required_lambda_actions() -> None:
+    """Lambda statement must include all actions needed for SAM deploy."""
+    policy = _load_policy()
+    allowed = _get_lambda_statement_actions(policy)
+    missing = REQUIRED_LAMBDA_ACTIONS - allowed
+    assert not missing, (
+        f"Missing Lambda actions in infra/github-deploy-policy.json: {sorted(missing)}. "
+        "These cause 403 AccessDenied during sam deploy. Add them to the Lambda statement."
+    )


### PR DESCRIPTION
## What changed
- **Deploy policy** – Added `lambda:TagResource` and `lambda:UntagResource` to the GitHub deploy role in `infra/github-deploy-policy.json`.
- **Lambda memory** – `DetailsChunkFunction`: 1024→512 MB; `ValidateFunction`: 1024→1536 MB in `template.yaml`.
- **Deploy policy test** – New `tests/test_github_deploy_policy.py` that checks the deploy policy includes the required Lambda actions.

## Why
Deployments were failing with `UPDATE_ROLLBACK_COMPLETE` because CloudFormation needs `lambda:TagResource` to tag new Lambda functions (e.g. `lambda:createdBy: SAM`); the deploy role did not have it. The memory settings are based on CloudWatch usage: `details_chunk` often under-uses its allocation, while `validate` needs more memory for large datasets. The new test detects missing deploy policy permissions before they cause 403s in CI.