### PR TITLE
feat(pipeline): Harden resilience to timeouts and connection errors

### DIFF
--- a/handlers/README.md
+++ b/handlers/README.md
@@ -53,14 +53,14 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
   "run_type": "custom",
   "run_name": "2024-01",
   "bucket": "fide-glicko",
-  "chunk_size": 300,
+  "chunk_size": 400,
   "override": false
 }
 ```
 - **run_type**, **run_name**: Used to locate `{base}/data/tournament_ids.txt`. No year/month
   required — paths derive from run folder.
 - **ids_uri**: Optional. Defaults to `{base}/data/tournament_ids.txt`
-- **chunk_size**: default 300
+- **chunk_size**: default 400
 - **chunk_count**: Optional override
 - Returns: `chunks: [{ input_path, output_path, tournament_count, chunk_index }, ...]`
 

--- a/handlers/details_chunk.py
+++ b/handlers/details_chunk.py
@@ -95,10 +95,11 @@ def lambda_handler(event: dict, context) -> dict:
     parquet_uri = output_path + ".parquet"
     if not override and output_exists(parquet_uri):
         return {
-            "statusCode": 409,
-            "success": False,
-            "error": "Output already exists; pass override=true to replace",
+            "statusCode": 200,
+            "success": True,
+            "skipped": True,
             "output_path": parquet_uri,
+            "message": "Output already exists; left as-is (pass override=true to replace)",
         }
 
     logger.info(

--- a/handlers/ensure_run_name.py
+++ b/handlers/ensure_run_name.py
@@ -14,7 +14,7 @@ Event shape (passthrough from execution input):
     "bucket": "fide-glicko",
     "override": false,
     "max_concurrency": 10,
-    "chunk_size": 300
+    "chunk_size": 400
 }
 
 Returns the same input with run_name set. Fails with 400 if validation fails.
@@ -50,5 +50,5 @@ def lambda_handler(event: dict, context) -> dict:
     # Apply defaults for optional fields
     out.setdefault("bucket", "fide-glicko")
     out.setdefault("override", False)
-    out.setdefault("chunk_size", 300)
+    out.setdefault("chunk_size", 400)
     return out

--- a/handlers/reports_chunk.py
+++ b/handlers/reports_chunk.py
@@ -92,10 +92,11 @@ def lambda_handler(event: dict, context) -> dict:
     games_uri = output_path + "_games.parquet"
     if not override and output_exists(games_uri):
         return {
-            "statusCode": 409,
-            "success": False,
-            "error": "Output already exists; pass override=true to replace",
+            "statusCode": 200,
+            "success": True,
+            "skipped": True,
             "output_path": games_uri,
+            "message": "Output already exists; left as-is (pass override=true to replace)",
         }
 
     if details_path is None:
@@ -119,7 +120,6 @@ def lambda_handler(event: dict, context) -> dict:
         output_path=output_path,
         details_path=details_path,
         rate_limit=0,
-        max_retries=3,
         quiet=False,
         save_raw=save_raw,
         output_sample_json=output_sample_json,

--- a/handlers/split_ids.py
+++ b/handlers/split_ids.py
@@ -7,7 +7,7 @@ Event shape:
     "run_name": "2024-01",
     "bucket": "fide-glicko",
     "ids_uri": null,
-    "chunk_size": 300,
+    "chunk_size": 400,
     "override": false
 }
 
@@ -17,7 +17,7 @@ Event shape:
 - bucket: S3 bucket (default: fide-glicko).
 - ids_uri: Path to tournament IDs file. If not set, uses {base}/data/tournament_ids.txt.
   Must exist; Step Function runs tournaments Lambda first.
-- chunk_size: Max tournaments per chunk (default: 300).
+- chunk_size: Max tournaments per chunk (default: 400).
 - override: Overwrite existing chunk files (default: false).
 
 Returns: { statusCode, success, chunks: [{ input_path, output_path, tournament_count, chunk_index }, ...] }
@@ -45,7 +45,7 @@ def lambda_handler(event: dict, context) -> dict:
     bucket = event.get("bucket", "fide-glicko")
     ids_uri = event.get("ids_uri")
     chunk_count = event.get("chunk_count")
-    chunk_size = event.get("chunk_size", 300)
+    chunk_size = event.get("chunk_size", 400)
     override = event.get("override", False)
 
     if run_type not in ("prod", "custom", "test"):
@@ -104,6 +104,7 @@ def lambda_handler(event: dict, context) -> dict:
         {
             "step": "split_ids",
             "chunk_count": len(chunks),
+            "chunk_size": chunk_size,
             "run_type": run_type,
             "run_name": run_name or "",
         },

--- a/handlers/tournaments.py
+++ b/handlers/tournaments.py
@@ -78,10 +78,11 @@ def lambda_handler(event: dict, context) -> dict:
 
     if not override and output_exists(ids_uri):
         return {
-            "statusCode": 409,
-            "success": False,
-            "error": "Output already exists; pass override=true to replace",
+            "statusCode": 200,
+            "success": True,
+            "skipped": True,
             "output_path": ids_uri,
+            "message": "Output already exists; left as-is (pass override=true to replace)",
         }
 
     if federations_s3_uri is None:

--- a/infra/step-function/README.md
+++ b/infra/step-function/README.md
@@ -66,7 +66,7 @@ aws stepfunctions start-execution \
 - **bucket** – S3 bucket (default: fide-glicko)
 - **override** – if true, refetch/overwrite even when cached (default: false)
 - **max_concurrency** – Map state parallelism for chunk processing (default: 10)
-- **chunk_size** – optional; default 300
+- **chunk_size** – optional; default 400
 
 ## Check status
 
@@ -88,3 +88,5 @@ aws stepfunctions get-execution-history --execution-arn EXECUTION_ARN
 ## Troubleshooting
 
 **ReportsChunk Lambda timeouts** – Each invocation has a 15 min max (Lambda limit). If a chunk times out (or Lambda.SdkClientException/Lambda.Unknown), the Map iterator retries it once (transient issues). Check CloudWatch Logs for `Slow report fetch`, `timeout`, `connection error` to diagnose anomalous chunks. For persistently slow months, re-run with smaller `chunk_size` (e.g. `150`).
+
+**Connect timeout (all-or-nothing per chunk)** – When a Lambda can't connect to ratings.fide.com, it typically fails for every tournament in that chunk. The scraper fails fast (15s connect timeout, abort after 2 consecutive) so the Step Function can retry with fresh Lambdas. ReportsChunk retries 5× and the Map retries 3× to avoid omitting tournaments due to transient connectivity.

--- a/infra/step-function/pipeline.asl.json
+++ b/infra/step-function/pipeline.asl.json
@@ -264,7 +264,7 @@
                   "Lambda.Unknown"
                 ],
                 "IntervalSeconds": 30,
-                "MaxAttempts": 1,
+                "MaxAttempts": 5,
                 "BackoffRate": 2
               }
             ],
@@ -281,9 +281,9 @@
       "Retry": [
         {
           "ErrorEquals": ["States.ALL"],
-          "IntervalSeconds": 10,
-          "MaxAttempts": 1,
-          "BackoffRate": 1
+          "IntervalSeconds": 30,
+          "MaxAttempts": 4,
+          "BackoffRate": 2
         }
       ],
       "Catch": [

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,7 +32,7 @@ uv run scripts/run_prod_backfill.py --start 2024-01 --end 2024-03 --dry-run
 | `--bucket` | S3 bucket (default: fide-glicko). |
 | `--override` | Pass override=true to pipeline. |
 | `--max-concurrency` | Map concurrency per execution (default: 10). |
-| `--chunk-size` | Max tournaments per chunk (default: 300). |
+| `--chunk-size` | Max tournaments per chunk (default: 400). |
 | `--dry-run` | List months without starting. |
 
 ## run_full_pipeline.py

--- a/src/scraper/get_tournament_details.py
+++ b/src/scraper/get_tournament_details.py
@@ -276,7 +276,8 @@ def fetch_tournament_details(
 
             t0 = time.perf_counter()
             try:
-                response = session.get(url, headers=headers, timeout=45)
+                # Connect 15s, read 45s (match reports; fail connect fast for all-or-nothing)
+                response = session.get(url, headers=headers, timeout=(15, 45))
             finally:
                 elapsed = time.perf_counter() - t0
                 attempt_times.append(elapsed)
@@ -375,6 +376,9 @@ def fetch_tournament_details(
                         "duration_s": attempt_times[-1] if attempt_times else 0,
                     }
                 )
+            # Connect timeout = all-or-nothing per Lambda; retries don't help
+            if "connect" in str(e).lower() and "timeout" in str(e).lower():
+                break
             continue
         except requests.exceptions.ConnectionError as e:
             error_str = str(e).lower()
@@ -903,6 +907,8 @@ def run(
         )
 
     start_time = time.time()
+    consecutive_connect_timeouts = 0
+    CONSECUTIVE_CONNECT_TIMEOUT_THRESHOLD = 2
 
     for pass_num in range(max_retries + 1):
         if not current_tournaments:
@@ -917,6 +923,7 @@ def run(
             )
             time.sleep(delay)
             total_retries += len(current_tournaments)
+            consecutive_connect_timeouts = 0  # reset on new pass
 
         pass_failed = []
         for tournament_id in current_tournaments:
@@ -936,6 +943,21 @@ def run(
                 result["success"] = False
                 result["error"] = error or "fetch failed"
                 error_lower = (error or "").lower()
+                is_connect_timeout = (
+                    "connect" in error_lower and "timeout" in error_lower
+                ) or "connecttimeout" in error_lower
+                if is_connect_timeout:
+                    consecutive_connect_timeouts += 1
+                    if (
+                        consecutive_connect_timeouts
+                        >= CONSECUTIVE_CONNECT_TIMEOUT_THRESHOLD
+                    ):
+                        raise RuntimeError(
+                            f"Details fetch: {CONSECUTIVE_CONNECT_TIMEOUT_THRESHOLD} consecutive "
+                            "connect timeouts; aborting chunk so Step Function can retry with fresh Lambda"
+                        ) from None
+                else:
+                    consecutive_connect_timeouts = 0
                 network_error_patterns = [
                     "eof",
                     "connection reset",
@@ -952,6 +974,7 @@ def run(
                 ):
                     pass_failed.append(tournament_id)
             else:
+                consecutive_connect_timeouts = 0
                 success_count += 1
                 result["success"] = True
                 result["details"] = details

--- a/src/scraper/get_tournament_reports.py
+++ b/src/scraper/get_tournament_reports.py
@@ -447,7 +447,9 @@ def fetch_tournament_report(
     """
     url = f"https://ratings.fide.com/tournament_src_report.phtml?code={tournament_code}"
 
-    max_retries = 3
+    max_retries = 2
+    # Fail fast on connect: 15s to establish, 45s to read (large report pages)
+    connect_timeout, read_timeout = 15, 45
     last_error = None
     attempt_times: List[float] = []
 
@@ -474,7 +476,9 @@ def fetch_tournament_report(
 
             t0 = time.perf_counter()
             try:
-                response = session.get(url, headers=headers, timeout=45)
+                response = session.get(
+                    url, headers=headers, timeout=(connect_timeout, read_timeout)
+                )
             finally:
                 elapsed = time.perf_counter() - t0
                 attempt_times.append(elapsed)
@@ -677,6 +681,9 @@ def fetch_tournament_report(
                         "duration_s": attempt_times[-1] if attempt_times else 0,
                     }
                 )
+            # Connect timeout = all-or-nothing per Lambda; retries don't help
+            if "connect" in str(e).lower() and "timeout" in str(e).lower():
+                break
             continue
         except requests.exceptions.ConnectionError as e:
             error_str = str(e).lower()
@@ -1398,7 +1405,6 @@ def run(
     output_path: str,
     details_path: Optional[str] = None,
     rate_limit: float = 0.5,
-    max_retries: int = 3,
     quiet: bool = False,
     limit: int = 0,
     save_raw: bool = True,
@@ -1414,7 +1420,6 @@ def run(
             {output_path}_games.parquet.
         details_path: Optional path to tournament_details parquet for date inference.
         rate_limit: Requests per second (0 = no limit, natural throughput).
-        max_retries: Retry passes for failed fetches.
         quiet: Reduce log output.
         limit: Process only first N codes (0 = all).
         save_raw: If True, save concatenated raw HTML to raw/reports/reports_chunk_{i}.html.gz.
@@ -1492,7 +1497,6 @@ def run(
 
     all_results: List[Dict] = []
     success_count = 0
-    error_count = 0
     current_codes = codes
 
     pbar = None
@@ -1508,66 +1512,30 @@ def run(
 
     start_time = time.time()
 
-    for pass_num in range(max_retries + 1):
-        if not current_codes:
-            break
-        if pass_num > 0:
-            delay = 3 * (2 ** (pass_num - 1))
-            logger.info(
-                "Retry pass %d: waiting %s before retrying %d tournaments",
-                pass_num,
-                format_duration(delay),
-                len(current_codes),
-            )
-            time.sleep(delay)
+    for code in current_codes:
+        if rate_limiter:
+            rate_limiter.wait()
+        report, error, _, raw_content = fetch_tournament_report(
+            code, session, return_raw=save_raw
+        )
 
-        pass_failed = []
-        for code in current_codes:
-            if rate_limiter:
-                rate_limiter.wait()
-            report, error, _, raw_content = fetch_tournament_report(
-                code, session, return_raw=save_raw
-            )
+        result = {"tournament_code": code}
+        if report is None:
+            raise RuntimeError(
+                f"Report fetch failed for tournament {code}: {error or 'unknown'}; "
+                "aborting chunk so Step Function can retry with fresh Lambda"
+            ) from None
 
-            result = {"tournament_code": code}
-            if report is None:
-                logger.warning(
-                    "Report fetch failed: tournament_code=%s error=%s",
-                    code,
-                    error or "unknown",
-                )
-                error_count += 1
-                result["success"] = False
-                result["error"] = error or "fetch failed"
-                error_lower = (error or "").lower()
-                network_error_patterns = [
-                    "eof",
-                    "connection reset",
-                    "connection aborted",
-                    "remotedisconnected",
-                    "remote end closed",
-                    "broken pipe",
-                ]
-                is_network_error = any(p in error_lower for p in network_error_patterns)
-                if (
-                    error
-                    and (is_network_error or "timeout" in error_lower)
-                    and pass_num < max_retries
-                ):
-                    pass_failed.append(code)
-            else:
-                success_count += 1
-                result["success"] = True
-                result.update(report)
-                if raw_base and raw_content:
-                    raw_accumulator.append((code, raw_content))
+        success_count += 1
+        result["success"] = True
+        result.update(report)
+        if raw_base and raw_content:
+            raw_accumulator.append((code, raw_content))
 
-            all_results.append(result)
-            if pbar:
-                pbar.update(1)
-                pbar.set_postfix({"✓": success_count, "✗": error_count})
-
-        current_codes = pass_failed
+        all_results.append(result)
+        if pbar:
+            pbar.update(1)
+            pbar.set_postfix({"✓": success_count})
 
     if pbar:
         pbar.close()
@@ -1597,12 +1565,7 @@ def run(
         save_csv_sample_from_parquet(games_path, output_sample_csv, sample_size=100)
 
     elapsed = time.time() - start_time
-    logger.info(
-        "Done: %d success, %d errors in %s",
-        success_count,
-        error_count,
-        format_duration(elapsed),
-    )
+    logger.info("Done: %d tournaments in %s", success_count, format_duration(elapsed))
     return 0
 
 

--- a/src/scraper/split_tournament_ids.py
+++ b/src/scraper/split_tournament_ids.py
@@ -73,6 +73,33 @@ def _output_exists(path: str) -> bool:
     return Path(path).exists()
 
 
+def _count_existing_id_chunks(run_base: str, bucket: str, n_chunks: int) -> int:
+    """Count existing ids_chunk_*.txt files. Used to detect chunk param changes."""
+    if _is_s3(run_base):
+        try:
+            from s3_io import list_s3_objects, parse_s3_uri
+
+            bucket_name, key_prefix = parse_s3_uri(run_base)
+            chunk_prefix = f"{key_prefix}/data/tournament_id_chunks/"
+            objects = list_s3_objects(bucket_name, chunk_prefix)
+            # Count keys like ids_chunk_0.txt, ids_chunk_1.txt, ...
+            prefix = "ids_chunk_"
+            suffix = ".txt"
+            count = sum(
+                1
+                for k, _ in objects
+                if k.split("/")[-1].startswith(prefix) and k.endswith(suffix)
+            )
+            return count
+        except Exception:
+            return 0
+    # Local
+    base = Path(run_base) / "data" / "tournament_id_chunks"
+    if not base.exists():
+        return 0
+    return sum(1 for p in base.glob("ids_chunk_*.txt") if p.is_file())
+
+
 def even_split(items: List[str], n: int) -> List[List[str]]:
     """Split list into n chunks as evenly as possible."""
     if n <= 0:
@@ -94,7 +121,7 @@ def even_split(items: List[str], n: int) -> List[List[str]]:
 def run(
     ids_path: str,
     chunk_count: Optional[int] = None,
-    chunk_size: int = 300,
+    chunk_size: int = 400,
     bucket: str = "fide-glicko",
     output_prefix: str = "data",
     chunk_prefix: str = "chunk",
@@ -108,7 +135,7 @@ def run(
     Args:
         ids_path: Path to tournament IDs file (one per line). S3 or local.
         chunk_count: Number of chunks (optional). If not set, derived from chunk_size.
-        chunk_size: Max tournaments per chunk when chunk_count not set (default: 300).
+        chunk_size: Max tournaments per chunk when chunk_count not set (default: 400).
         bucket: S3 bucket (for building chunk/output paths if using S3).
         output_prefix: S3 prefix when ids_path does not match standard structure.
         chunk_prefix: Prefix for chunk input files (unused with standard structure).
@@ -172,6 +199,18 @@ def run(
         [len(c) for c in chunks],
     )
 
+    # If chunk_size/chunk_count changed, existing files have wrong boundaries—must rewrite.
+    force_rewrite = False
+    if not override:
+        existing_count = _count_existing_id_chunks(run_base, bucket, n_chunks)
+        if existing_count != n_chunks:
+            force_rewrite = True
+            logger.info(
+                "Chunk params changed: existing=%d, needed=%d—rewriting id chunks",
+                existing_count,
+                n_chunks,
+            )
+
     result = []
     for i, chunk_ids in enumerate(chunks):
         chunk_content = "\n".join(chunk_ids) + "\n"
@@ -192,7 +231,7 @@ def run(
                 / f"details_chunk_{i}"
             )
 
-        if not override and _output_exists(chunk_input_path):
+        if not override and not force_rewrite and _output_exists(chunk_input_path):
             logger.info("Chunk %d already exists, skipping write", i)
         else:
             _write_chunk(chunk_content, chunk_input_path)
@@ -232,7 +271,7 @@ def main() -> int:
         "--chunk-size",
         type=int,
         default=300,
-        help="Max tournaments per chunk when chunk-count not set (default: 300)",
+        help="Max tournaments per chunk when chunk-count not set (default: 400)",
     )
     parser.add_argument(
         "--bucket",

--- a/template.yaml
+++ b/template.yaml
@@ -49,7 +49,7 @@ Resources:
       CodeUri: .functions/tournaments
       Handler: handlers.tournaments.lambda_handler
       Timeout: 900
-      MemorySize: 512
+      MemorySize: 256
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref DataBucket
@@ -95,6 +95,7 @@ Resources:
 
   ReportsChunkFunction:
     Type: AWS::Serverless::Function
+
     Metadata:
       DockerContext: .
       Dockerfile: docker/Dockerfile
@@ -106,7 +107,7 @@ Resources:
         Command:
           - handlers.reports_chunk.lambda_handler
       Timeout: 900
-      MemorySize: 2048
+      MemorySize: 1024
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref DataBucket


### PR DESCRIPTION
## What changed

- **Step Function**: Map retries 1→4, DetailsChunk timeout/SdkClient retries 1→5.
- **Output exists (override=false)**: Tournaments, DetailsChunk, ReportsChunk now return 200/success/skipped instead of 409 when output already exists. Pipeline treats skips as success.
- **Details scraper**: Timeout (15,45), connect timeout break, fail Lambda after 2 consecutive connect timeouts.
- **Reports scraper**: Timeout (15,45), connect timeout break, removed retry passes—raise on first failure.
- **SplitIds**: Default chunk_size 300→400. If existing `ids_chunk_*.txt` count ≠ n_chunks, force rewrite (even when override=false). Write chunk_size to run_metadata.
- **Lambda memory**: Tournaments 512→256 MB, ReportsChunk 2048→1024 MB.
- **Docs**: Updated defaults and troubleshooting for connect timeouts.

## Why

prod-run-25-01-3 failed on chunks 6 and 13 (DetailsChunk and ReportsChunk timeouts). Logs showed connect timeouts to ratings.fide.com; each tournament took ~46s (45s connect × 3 retries). Connect failures tend to affect the whole chunk, so per-tournament retries were ineffective.

Decisions:
- **Fail fast on connect timeout**: 15s connect timeout, abort after 2 consecutive. Step Function retries with fresh Lambdas.
- **ReportsChunk fail-fast**: Raise on first failure instead of retrying in Lambda; Step Function handles retries.
- **Output-exists → 200**: Treat "output exists, override=false" as success so the pipeline doesn’t fail on skips.
- **SplitIds force rewrite**: If chunk_size or chunk_count changes, existing id chunks are invalid; rewrite regardless of override.
- **Chunk size 400**: Fewer chunks to reduce Lambda and Step Function overhead.