### PR TITLE
feat(pipeline): Use chunk naming ids_chunk_{i}_of_{n} and fix merge schema

### DIFF
--- a/handlers/README.md
+++ b/handlers/README.md
@@ -53,14 +53,14 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
   "run_type": "custom",
   "run_name": "2024-01",
   "bucket": "fide-glicko",
-  "chunk_size": 400,
+  "chunk_size": 300,
   "override": false
 }
 ```
 - **run_type**, **run_name**: Used to locate `{base}/data/tournament_ids.txt`. No year/month
   required — paths derive from run folder.
 - **ids_uri**: Optional. Defaults to `{base}/data/tournament_ids.txt`
-- **chunk_size**: default 400
+- **chunk_size**: default 300
 - **chunk_count**: Optional override
 - Returns: `chunks: [{ input_path, output_path, tournament_count, chunk_index }, ...]`
 
@@ -74,9 +74,9 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
   "override": false
 }
 ```
-- **chunk_index**: Required (0-based). Paths: `{base}/data/tournament_id_chunks/ids_chunk_{i}.txt` → `{base}/data/tournament_details_chunks/details_chunk_{i}.parquet`
+- **chunk_index**: Required (0-based). **chunk_count**: Required. Paths: `{base}/data/tournament_id_chunks/ids_chunk_{i}_of_{n}.txt` → `{base}/data/tournament_details_chunks/details_chunk_{i}_of_{n}.parquet`
 - **override**: If true, overwrite existing output (default: false)
-- **save_raw**: If true, save raw HTML to `{base}/raw/details/details_chunk_{i}.html.gz` (default: false)
+- **save_raw**: If true, save raw HTML to `{base}/raw/details/details_chunk_{i}_of_{n}.html.gz` (default: false)
 - Orchestrator: use `chunk_index` from each split_ids chunk, pass run_type/run_name from state
 
 ### reports_chunk
@@ -90,11 +90,11 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
   "save_raw": false
 }
 ```
-- **chunk_index**: Required (0-based). Paths: `{base}/data/tournament_id_chunks/ids_chunk_{i}.txt` → `{base}/data/tournament_reports_chunks/reports_chunk_{i}_*.parquet`
+- **chunk_index**: Required (0-based). **chunk_count**: Required. Paths: `{base}/data/tournament_id_chunks/ids_chunk_{i}_of_{n}.txt` → `{base}/data/tournament_reports_chunks/reports_chunk_{i}_of_{n}_*.parquet`
 - **override**: If true, overwrite existing output (default: false)
 - **save_raw**: If true, save raw HTML to `{base}/raw/reports/reports_chunk_{i}.html.gz` (default: false)
-- **details_path**: Optional. Defaults to `{base}/data/tournament_details_chunks/details_chunk_{i}.parquet`
-- Outputs: `reports_chunk_{i}_players.parquet`, `reports_chunk_{i}_games.parquet`; `reports_chunk_{i}_verbose_sample.json`, `reports_chunk_{i}_games_sample.csv`
+- **details_path**: Optional. Defaults to `{base}/data/tournament_details_chunks/details_chunk_{i}_of_{n}.parquet`
+- Outputs: `reports_chunk_{i}_of_{n}_players.parquet`, `reports_chunk_{i}_of_{n}_games.parquet`; `reports_chunk_{i}_of_{n}_verbose_sample.json`, `reports_chunk_{i}_of_{n}_games_sample.csv`
 - Orchestrator: use `chunk_index` from each split_ids chunk, pass run_type/run_name from state
 
 ### merge_chunks
@@ -109,7 +109,7 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
 - **run_type**, **run_name**: Required (as above). Locates chunk prefixes.
 - **bucket**: default fide-glicko
 - **override**: If true, overwrite existing merged files (default: false)
-- Inputs: `{base}/data/tournament_details_chunks/details_chunk_*.parquet`, `{base}/data/tournament_reports_chunks/reports_chunk_*_players.parquet`, `reports_chunk_*_games.parquet`
+- Inputs: `{base}/data/tournament_details_chunks/details_chunk_*_of_{n}.parquet`, `{base}/data/tournament_reports_chunks/reports_chunk_*_of_{n}_players.parquet`, `reports_chunk_*_of_{n}_games.parquet` (n=chunk_count from run_metadata)
 - Outputs: `{base}/data/tournament_details.parquet`, `{base}/data/tournament_reports_players.parquet`, `{base}/data/tournament_reports_games.parquet`
 - Returns: `details_uri`, `reports_players_uri`, `reports_games_uri`, `details_chunks`, `reports_chunks`
 

--- a/handlers/details_chunk.py
+++ b/handlers/details_chunk.py
@@ -48,6 +48,7 @@ def lambda_handler(event: dict, context) -> dict:
     run_type = event.get("run_type", "custom")
     run_name = event.get("run_name")
     chunk_index = event.get("chunk_index")
+    chunk_count = event.get("chunk_count")
     bucket = event.get("bucket", "fide-glicko")
     override = event.get("override", False)
     save_raw = event.get("save_raw", True)
@@ -70,6 +71,12 @@ def lambda_handler(event: dict, context) -> dict:
             "success": False,
             "error": "chunk_index is required",
         }
+    if chunk_count is None:
+        return {
+            "statusCode": 400,
+            "success": False,
+            "error": "chunk_count is required",
+        }
 
     input_path = build_s3_uri_for_run(
         bucket,
@@ -77,7 +84,7 @@ def lambda_handler(event: dict, context) -> dict:
         run_name,
         "data",
         "tournament_id_chunks",
-        f"ids_chunk_{chunk_index}.txt",
+        f"ids_chunk_{chunk_index}_of_{chunk_count}.txt",
     )
     output_path = build_s3_uri_for_run(
         bucket,
@@ -85,7 +92,7 @@ def lambda_handler(event: dict, context) -> dict:
         run_name,
         "data",
         "tournament_details_chunks",
-        f"details_chunk_{chunk_index}",
+        f"details_chunk_{chunk_index}_of_{chunk_count}",
     )
 
     output_sample_path, output_reports_base = _derive_sample_and_reports_paths(

--- a/handlers/ensure_run_name.py
+++ b/handlers/ensure_run_name.py
@@ -14,7 +14,7 @@ Event shape (passthrough from execution input):
     "bucket": "fide-glicko",
     "override": false,
     "max_concurrency": 10,
-    "chunk_size": 400
+    "chunk_size": 300
 }
 
 Returns the same input with run_name set. Fails with 400 if validation fails.
@@ -50,5 +50,5 @@ def lambda_handler(event: dict, context) -> dict:
     # Apply defaults for optional fields
     out.setdefault("bucket", "fide-glicko")
     out.setdefault("override", False)
-    out.setdefault("chunk_size", 400)
+    out.setdefault("chunk_size", 300)
     return out

--- a/handlers/merge_chunks.py
+++ b/handlers/merge_chunks.py
@@ -14,8 +14,9 @@ Event shape:
 - bucket: S3 bucket (default: fide-glicko)
 - override: If true, overwrite existing merged files (default: false)
 
-Inputs: {base}/data/tournament_details_chunks/details_chunk_*.parquet,
-        {base}/data/tournament_reports_chunks/reports_chunk_*_players.parquet, reports_chunk_*_games.parquet
+Inputs: {base}/data/tournament_details_chunks/details_chunk_*_of_{n}.parquet,
+        {base}/data/tournament_reports_chunks/reports_chunk_*_of_{n}_players.parquet, reports_chunk_*_of_{n}_games.parquet
+        (n=chunk_count from run_metadata.json)
 Outputs: {base}/data/tournament_details.parquet,
          {base}/data/tournament_reports_players.parquet,
          {base}/data/tournament_reports_games.parquet

--- a/handlers/reports_chunk.py
+++ b/handlers/reports_chunk.py
@@ -46,6 +46,7 @@ def lambda_handler(event: dict, context) -> dict:
     run_type = event.get("run_type", "custom")
     run_name = event.get("run_name")
     chunk_index = event.get("chunk_index")
+    chunk_count = event.get("chunk_count")
     bucket = event.get("bucket", "fide-glicko")
     override = event.get("override", False)
     save_raw = event.get("save_raw", True)
@@ -69,6 +70,12 @@ def lambda_handler(event: dict, context) -> dict:
             "success": False,
             "error": "chunk_index is required",
         }
+    if chunk_count is None:
+        return {
+            "statusCode": 400,
+            "success": False,
+            "error": "chunk_count is required",
+        }
 
     input_path = build_s3_uri_for_run(
         bucket,
@@ -76,7 +83,7 @@ def lambda_handler(event: dict, context) -> dict:
         run_name,
         "data",
         "tournament_id_chunks",
-        f"ids_chunk_{chunk_index}.txt",
+        f"ids_chunk_{chunk_index}_of_{chunk_count}.txt",
     )
     output_path = build_s3_uri_for_run(
         bucket,
@@ -84,7 +91,7 @@ def lambda_handler(event: dict, context) -> dict:
         run_name,
         "data",
         "tournament_reports_chunks",
-        f"reports_chunk_{chunk_index}",
+        f"reports_chunk_{chunk_index}_of_{chunk_count}",
     )
 
     output_sample_json, output_sample_csv = _derive_sample_paths(output_path)
@@ -106,7 +113,7 @@ def lambda_handler(event: dict, context) -> dict:
             run_name,
             "data",
             "tournament_details_chunks",
-            f"details_chunk_{chunk_index}.parquet",
+            f"details_chunk_{chunk_index}_of_{chunk_count}.parquet",
         )
 
     logger.info(

--- a/handlers/split_ids.py
+++ b/handlers/split_ids.py
@@ -7,7 +7,7 @@ Event shape:
     "run_name": "2024-01",
     "bucket": "fide-glicko",
     "ids_uri": null,
-    "chunk_size": 400,
+    "chunk_size": 300,
     "override": false
 }
 
@@ -17,7 +17,7 @@ Event shape:
 - bucket: S3 bucket (default: fide-glicko).
 - ids_uri: Path to tournament IDs file. If not set, uses {base}/data/tournament_ids.txt.
   Must exist; Step Function runs tournaments Lambda first.
-- chunk_size: Max tournaments per chunk (default: 400).
+- chunk_size: Max tournaments per chunk (default: 300).
 - override: Overwrite existing chunk files (default: false).
 
 Returns: { statusCode, success, chunks: [{ input_path, output_path, tournament_count, chunk_index }, ...] }
@@ -45,7 +45,7 @@ def lambda_handler(event: dict, context) -> dict:
     bucket = event.get("bucket", "fide-glicko")
     ids_uri = event.get("ids_uri")
     chunk_count = event.get("chunk_count")
-    chunk_size = event.get("chunk_size", 400)
+    chunk_size = event.get("chunk_size", 300)
     override = event.get("override", False)
 
     if run_type not in ("prod", "custom", "test"):

--- a/infra/README.md
+++ b/infra/README.md
@@ -100,12 +100,12 @@ s3://fide-glicko/
 │       ├── data/
 │       │   ├── tournament_ids.txt
 │       │   ├── tournament_id_chunks/
-│       │   │   └── ids_chunk_{N}.txt
+│       │   │   └── ids_chunk_{N}_of_{total}.txt
 │       │   ├── tournament_details_chunks/
-│       │   │   └── details_chunk_{N}.parquet
+│       │   │   └── details_chunk_{N}_of_{total}.parquet
 │       │   ├── tournament_reports_chunks/
-│       │   │   ├── reports_chunk_{N}_players.parquet
-│       │   │   └── reports_chunk_{N}_games.parquet
+│       │   │   ├── reports_chunk_{N}_of_{total}_players.parquet
+│       │   │   └── reports_chunk_{N}_of_{total}_games.parquet
 │       │   ├── tournament_details.parquet
 │       │   ├── tournament_reports_players.parquet
 │       │   └── tournament_reports_games.parquet

--- a/infra/step-function/README.md
+++ b/infra/step-function/README.md
@@ -66,7 +66,7 @@ aws stepfunctions start-execution \
 - **bucket** – S3 bucket (default: fide-glicko)
 - **override** – if true, refetch/overwrite even when cached (default: false)
 - **max_concurrency** – Map state parallelism for chunk processing (default: 10)
-- **chunk_size** – optional; default 400
+- **chunk_size** – optional; default 300
 
 ## Check status
 
@@ -89,4 +89,4 @@ aws stepfunctions get-execution-history --execution-arn EXECUTION_ARN
 
 **ReportsChunk Lambda timeouts** – Each invocation has a 15 min max (Lambda limit). If a chunk times out (or Lambda.SdkClientException/Lambda.Unknown), the Map iterator retries it once (transient issues). Check CloudWatch Logs for `Slow report fetch`, `timeout`, `connection error` to diagnose anomalous chunks. For persistently slow months, re-run with smaller `chunk_size` (e.g. `150`).
 
-**Connect timeout (all-or-nothing per chunk)** – When a Lambda can't connect to ratings.fide.com, it typically fails for every tournament in that chunk. The scraper fails fast (15s connect timeout, abort after 2 consecutive) so the Step Function can retry with fresh Lambdas. ReportsChunk retries 5× and the Map retries 3× to avoid omitting tournaments due to transient connectivity.
+**Connect timeout (all-or-nothing per chunk)** – When a Lambda can't connect to ratings.fide.com, it typically fails for every tournament in that chunk. The scraper fails fast (15s connect timeout, abort after 2 consecutive) so the Step Function can retry with fresh Lambdas. DetailsChunk errors go to ChunkFailed (Pass state); ReportsChunk has no Catch so its failures surface as MapIterationFailed. The Map retries 4× to handle transient connectivity.

--- a/infra/step-function/pipeline.asl.json
+++ b/infra/step-function/pipeline.asl.json
@@ -183,6 +183,7 @@
         "run_type.$": "$$.Map.Item.Value.run_type",
         "run_name.$": "$$.Map.Item.Value.run_name",
         "chunk_index.$": "$$.Map.Item.Value.chunk_index",
+        "chunk_count.$": "$$.Map.Item.Value.chunk_count",
         "bucket.$": "$$.Execution.Input.bucket",
         "override.$": "$$.Execution.Input.override"
       },
@@ -196,6 +197,7 @@
               "run_type.$": "$.run_type",
               "run_name.$": "$.run_name",
               "chunk_index.$": "$.chunk_index",
+              "chunk_count.$": "$.chunk_count",
               "bucket.$": "$.bucket",
               "override.$": "$.override"
             },
@@ -220,7 +222,7 @@
                   "Lambda.Unknown"
                 ],
                 "IntervalSeconds": 30,
-                "MaxAttempts": 1,
+                "MaxAttempts": 5,
                 "BackoffRate": 2
               }
             ],
@@ -240,6 +242,7 @@
               "run_type.$": "$.run_type",
               "run_name.$": "$.run_name",
               "chunk_index.$": "$.chunk_index",
+              "chunk_count.$": "$.chunk_count",
               "bucket.$": "$.bucket",
               "override.$": "$.override",
               "save_raw": true

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,7 +32,7 @@ uv run scripts/run_prod_backfill.py --start 2024-01 --end 2024-03 --dry-run
 | `--bucket` | S3 bucket (default: fide-glicko). |
 | `--override` | Pass override=true to pipeline. |
 | `--max-concurrency` | Map concurrency per execution (default: 10). |
-| `--chunk-size` | Max tournaments per chunk (default: 400). |
+| `--chunk-size` | Max tournaments per chunk (default: 300). |
 | `--dry-run` | List months without starting. |
 
 ## run_full_pipeline.py

--- a/src/scraper/get_tournament_details.py
+++ b/src/scraper/get_tournament_details.py
@@ -629,10 +629,17 @@ def save_time_control_unique_values(results: List[Dict], output_path: str):
         logger.error(f"Time control unique values save failed: {e}")
 
 
+# Columns that can be int or None across chunks; use float64 for consistent Parquet schema
+_NULLABLE_NUMERIC_COLS = ("n_players",)
+
+
 def save_results_parquet(results: List[Dict], parquet_path: str) -> None:
     """Save results as Parquet file (local or S3)."""
     try:
         df = results_to_dataframe(results)
+        for col in _NULLABLE_NUMERIC_COLS:
+            if col in df.columns:
+                df[col] = df[col].astype("float64")
         buf = io.BytesIO()
         df.to_parquet(buf, index=False, engine="pyarrow")
         _write_to_path(parquet_path, buf.getvalue())

--- a/src/scraper/merge_chunks.py
+++ b/src/scraper/merge_chunks.py
@@ -15,10 +15,24 @@ import re
 
 logger = logging.getLogger(__name__)
 
-# Chunk filenames: details_chunk_0.parquet, reports_chunk_0_players.parquet, ...
-DETAILS_CHUNK_RE = re.compile(r"details_chunk_(\d+)\.parquet$")
-REPORTS_PLAYERS_RE = re.compile(r"reports_chunk_(\d+)_players\.parquet$")
-REPORTS_GAMES_RE = re.compile(r"reports_chunk_(\d+)_games\.parquet$")
+
+# Chunk filenames: details_chunk_0_of_15.parquet (new) or details_chunk_0.parquet (legacy)
+def _details_re(n: int | None) -> re.Pattern:
+    if n is not None:
+        return re.compile(rf"details_chunk_(\d+)_of_{n}\.parquet$")
+    return re.compile(r"details_chunk_(\d+)\.parquet$")
+
+
+def _reports_players_re(n: int | None) -> re.Pattern:
+    if n is not None:
+        return re.compile(rf"reports_chunk_(\d+)_of_{n}_players\.parquet$")
+    return re.compile(r"reports_chunk_(\d+)_players\.parquet$")
+
+
+def _reports_games_re(n: int | None) -> re.Pattern:
+    if n is not None:
+        return re.compile(rf"reports_chunk_(\d+)_of_{n}_games\.parquet$")
+    return re.compile(r"reports_chunk_(\d+)_games\.parquet$")
 
 
 def _parse_chunk_index(key: str, pattern: re.Pattern) -> int | None:
@@ -68,6 +82,7 @@ def run(
         list_s3_objects,
         output_exists,
         parse_s3_uri,
+        read_run_metadata,
         write_run_metadata,
     )
 
@@ -75,25 +90,30 @@ def run(
         logging.getLogger().setLevel(logging.WARNING)
 
     base = build_run_base(run_type, run_name)
+    base_uri = f"s3://{bucket}/{base}"
+    metadata = read_run_metadata(base_uri)
+    chunk_count = metadata.get("chunk_count") if metadata else None
+
     details_prefix = f"{base}/data/tournament_details_chunks/"
     reports_prefix = f"{base}/data/tournament_reports_chunks/"
 
-    # List chunk files
     details_objs = list_s3_objects(bucket, details_prefix)
     reports_objs = list_s3_objects(bucket, reports_prefix)
 
-    details_keys = _sorted_chunk_keys([k for k, _ in details_objs], DETAILS_CHUNK_RE)
-    players_keys = _sorted_chunk_keys([k for k, _ in reports_objs], REPORTS_PLAYERS_RE)
-    games_keys = _sorted_chunk_keys([k for k, _ in reports_objs], REPORTS_GAMES_RE)
-
-    if not details_keys:
+    # Prefer new naming (_of_{n}); fall back to legacy for existing runs
+    for try_chunk_count in [chunk_count, None]:
+        details_re = _details_re(try_chunk_count)
+        players_re = _reports_players_re(try_chunk_count)
+        games_re = _reports_games_re(try_chunk_count)
+        details_keys = _sorted_chunk_keys([k for k, _ in details_objs], details_re)
+        players_keys = _sorted_chunk_keys([k for k, _ in reports_objs], players_re)
+        games_keys = _sorted_chunk_keys([k for k, _ in reports_objs], games_re)
+        if details_keys and players_keys and games_keys:
+            break
+    else:
         raise RuntimeError(
-            f"No details chunks found under s3://{bucket}/{details_prefix}"
-        )
-    if not players_keys or not games_keys:
-        raise RuntimeError(
-            f"No reports chunks found under s3://{bucket}/{reports_prefix} "
-            "(need reports_chunk_*_players.parquet and reports_chunk_*_games.parquet)"
+            f"No details/reports chunks found under s3://{bucket}/{details_prefix} "
+            f"(tried both details_chunk_*_of_{{n}}.parquet and details_chunk_*.parquet)"
         )
 
     details_uri = build_s3_uri_for_run(
@@ -134,6 +154,19 @@ def run(
         obj = s3.get_object(Bucket=bucket, Key=key)
         return pq.read_table(io.BytesIO(obj["Body"].read()))
 
+    def _concat_tables_unified(tables: list[pa.Table]) -> pa.Table:
+        """Concat tables, unifying schemas (e.g. n_players int64 vs double)."""
+        if not tables:
+            return pa.table({})
+        try:
+            return pa.concat_tables(tables, promote_options="permissive")
+        except pa.ArrowInvalid:
+            # Fallback: pandas concat handles mixed types (PyArrow < 14 or edge cases)
+            import pandas as pd
+
+            dfs = [t.to_pandas() for t in tables]
+            return pa.Table.from_pandas(pd.concat(dfs, ignore_index=True))
+
     def _write_parquet(table: pa.Table, uri: str) -> None:
         buf = io.BytesIO()
         pq.write_table(table, buf)
@@ -144,7 +177,7 @@ def run(
     # Merge details
     logger.info("Merging %d details chunks -> %s", len(details_keys), details_uri)
     details_tables = [_read_parquet(k) for k in details_keys]
-    details_merged = pa.concat_tables(details_tables)
+    details_merged = _concat_tables_unified(details_tables)
     _write_parquet(details_merged, details_uri)
     del details_tables, details_merged
 
@@ -153,14 +186,14 @@ def run(
         "Merging %d reports players chunks -> %s", len(players_keys), players_uri
     )
     players_tables = [_read_parquet(k) for k in players_keys]
-    players_merged = pa.concat_tables(players_tables)
+    players_merged = _concat_tables_unified(players_tables)
     _write_parquet(players_merged, players_uri)
     del players_tables, players_merged
 
     # Merge reports games
     logger.info("Merging %d reports games chunks -> %s", len(games_keys), games_uri)
     games_tables = [_read_parquet(k) for k in games_keys]
-    games_merged = pa.concat_tables(games_tables)
+    games_merged = _concat_tables_unified(games_tables)
     _write_parquet(games_merged, games_uri)
 
     base_uri = f"s3://{bucket}/{base}"

--- a/src/scraper/s3_io.py
+++ b/src/scraper/s3_io.py
@@ -264,6 +264,27 @@ def get_latest_in_local_prefix(
     return files[0][0], files[0][1]
 
 
+def read_run_metadata(base_path: str | Path) -> dict | None:
+    """
+    Read run_metadata.json from run root. Returns dict or None if not found.
+    base_path: S3 URI (s3://bucket/prod/2024-01) or local path.
+    """
+    if is_s3_path(str(base_path)):
+        try:
+            import boto3
+
+            bucket, key_prefix = parse_s3_uri(str(base_path))
+            s3 = boto3.client("s3")
+            obj = s3.get_object(Bucket=bucket, Key=f"{key_prefix}/run_metadata.json")
+            return json.loads(obj["Body"].read().decode("utf-8"))
+        except Exception:
+            return None
+    path = Path(base_path) / "run_metadata.json"
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def write_run_metadata(
     base_path: str | Path,
     metadata: dict,

--- a/src/scraper/split_tournament_ids.py
+++ b/src/scraper/split_tournament_ids.py
@@ -73,33 +73,6 @@ def _output_exists(path: str) -> bool:
     return Path(path).exists()
 
 
-def _count_existing_id_chunks(run_base: str, bucket: str, n_chunks: int) -> int:
-    """Count existing ids_chunk_*.txt files. Used to detect chunk param changes."""
-    if _is_s3(run_base):
-        try:
-            from s3_io import list_s3_objects, parse_s3_uri
-
-            bucket_name, key_prefix = parse_s3_uri(run_base)
-            chunk_prefix = f"{key_prefix}/data/tournament_id_chunks/"
-            objects = list_s3_objects(bucket_name, chunk_prefix)
-            # Count keys like ids_chunk_0.txt, ids_chunk_1.txt, ...
-            prefix = "ids_chunk_"
-            suffix = ".txt"
-            count = sum(
-                1
-                for k, _ in objects
-                if k.split("/")[-1].startswith(prefix) and k.endswith(suffix)
-            )
-            return count
-        except Exception:
-            return 0
-    # Local
-    base = Path(run_base) / "data" / "tournament_id_chunks"
-    if not base.exists():
-        return 0
-    return sum(1 for p in base.glob("ids_chunk_*.txt") if p.is_file())
-
-
 def even_split(items: List[str], n: int) -> List[List[str]]:
     """Split list into n chunks as evenly as possible."""
     if n <= 0:
@@ -121,7 +94,7 @@ def even_split(items: List[str], n: int) -> List[List[str]]:
 def run(
     ids_path: str,
     chunk_count: Optional[int] = None,
-    chunk_size: int = 400,
+    chunk_size: int = 300,
     bucket: str = "fide-glicko",
     output_prefix: str = "data",
     chunk_prefix: str = "chunk",
@@ -135,7 +108,7 @@ def run(
     Args:
         ids_path: Path to tournament IDs file (one per line). S3 or local.
         chunk_count: Number of chunks (optional). If not set, derived from chunk_size.
-        chunk_size: Max tournaments per chunk when chunk_count not set (default: 400).
+        chunk_size: Max tournaments per chunk when chunk_count not set (default: 300).
         bucket: S3 bucket (for building chunk/output paths if using S3).
         output_prefix: S3 prefix when ids_path does not match standard structure.
         chunk_prefix: Prefix for chunk input files (unused with standard structure).
@@ -199,39 +172,32 @@ def run(
         [len(c) for c in chunks],
     )
 
-    # If chunk_size/chunk_count changed, existing files have wrong boundaries—must rewrite.
-    force_rewrite = False
-    if not override:
-        existing_count = _count_existing_id_chunks(run_base, bucket, n_chunks)
-        if existing_count != n_chunks:
-            force_rewrite = True
-            logger.info(
-                "Chunk params changed: existing=%d, needed=%d—rewriting id chunks",
-                existing_count,
-                n_chunks,
-            )
+    # With _of_{n} naming, different chunk sizes produce different paths—no force_rewrite needed.
 
     result = []
     for i, chunk_ids in enumerate(chunks):
         chunk_content = "\n".join(chunk_ids) + "\n"
-        # Structure: tournament_id_chunks/ids_chunk_{i}.txt, tournament_details_chunks/details_chunk_{i}
+        # Structure: tournament_id_chunks/ids_chunk_{i}_of_{n}.txt (n=chunk_count disambiguates runs)
         if _is_s3(run_base):
-            chunk_input_path = f"{run_base}/data/tournament_id_chunks/ids_chunk_{i}.txt"
-            chunk_output_path = (
-                f"{run_base}/data/tournament_details_chunks/details_chunk_{i}"
+            chunk_input_path = (
+                f"{run_base}/data/tournament_id_chunks/ids_chunk_{i}_of_{n_chunks}.txt"
             )
+            chunk_output_path = f"{run_base}/data/tournament_details_chunks/details_chunk_{i}_of_{n_chunks}"
         else:
             chunk_input_path = str(
-                Path(run_base) / "data" / "tournament_id_chunks" / f"ids_chunk_{i}.txt"
+                Path(run_base)
+                / "data"
+                / "tournament_id_chunks"
+                / f"ids_chunk_{i}_of_{n_chunks}.txt"
             )
             chunk_output_path = str(
                 Path(run_base)
                 / "data"
                 / "tournament_details_chunks"
-                / f"details_chunk_{i}"
+                / f"details_chunk_{i}_of_{n_chunks}"
             )
 
-        if not override and not force_rewrite and _output_exists(chunk_input_path):
+        if not override and _output_exists(chunk_input_path):
             logger.info("Chunk %d already exists, skipping write", i)
         else:
             _write_chunk(chunk_content, chunk_input_path)
@@ -245,6 +211,7 @@ def run(
                 "output_path": chunk_output_path,
                 "tournament_count": len(chunk_ids),
                 "chunk_index": i,
+                "chunk_count": n_chunks,
             }
         )
 
@@ -271,7 +238,7 @@ def main() -> int:
         "--chunk-size",
         type=int,
         default=300,
-        help="Max tournaments per chunk when chunk-count not set (default: 400)",
+        help="Max tournaments per chunk when chunk-count not set (default: 300)",
     )
     parser.add_argument(
         "--bucket",


### PR DESCRIPTION
## What changed
- Chunk paths now use `ids_chunk_{i}_of_{n}.txt`, `details_chunk_{i}_of_{n}`, `reports_chunk_{i}_of_{n}` (n = chunk_count).
- SplitIds adds `chunk_count` to each chunk; ItemSelector passes it to DetailsChunk and ReportsChunk.
- Merge reads `chunk_count` from `run_metadata.json`, supports both new and legacy chunk patterns.
- Merge uses `promote_options="permissive"` when concatenating parquet tables to handle schema differences.
- Details parquet: cast `n_players` to float64 before writing so all chunks share the same schema.
- Chunk size default reverted from 400 to 300.
- Removed `_count_existing_id_chunks` and `force_rewrite` from split_tournament_ids.
- Added `read_run_metadata()` in s3_io.

## Why
Chunk size changes caused runs to overwrite or mix old and new chunks. Including chunk_count in paths makes each layout distinct (e.g. `ids_chunk_0_of_12` vs `ids_chunk_0_of_15`), so re-runs with different chunk sizes write separate files and do not need override.

Merge was failing with ArrowInvalid when concatenating details chunks because `n_players` was sometimes int64 (no nulls) and sometimes double (nulls present). Fixing at the source by always writing `n_players` as float64 gives a stable schema. Merge also uses schema promotion for robustness.

Chunk size 300 was reverted because a run at 400 still hit timeouts.