### PR TITLE
feat(reports): Skip no-original-report tournaments, filter backfill by FIDE periods

### DIFF
--- a/handlers/README.md
+++ b/handlers/README.md
@@ -94,7 +94,7 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
 - **override**: If true, overwrite existing output (default: false)
 - **save_raw**: If true, save raw HTML to `{base}/raw/reports/reports_chunk_{i}.html.gz` (default: false)
 - **details_path**: Optional. Defaults to `{base}/data/tournament_details_chunks/details_chunk_{i}_of_{n}.parquet`
-- Outputs: `reports_chunk_{i}_of_{n}_players.parquet`, `reports_chunk_{i}_of_{n}_games.parquet`; `reports_chunk_{i}_of_{n}_verbose_sample.json`, `reports_chunk_{i}_of_{n}_games_sample.csv`
+- Outputs: `reports_chunk_{i}_of_{n}_players.parquet`, `reports_chunk_{i}_of_{n}_games.parquet`; `reports_chunk_{i}_of_{n}_verbose_sample.json`, `reports_chunk_{i}_of_{n}_games_sample.csv`; `{base}/reports/reports_chunk_{i}_of_{n}_skipped.json` when any tournaments have no original report (updated/replaced)
 - Orchestrator: use `chunk_index` from each split_ids chunk, pass run_type/run_name from state
 
 ### merge_chunks

--- a/handlers/reports_chunk.py
+++ b/handlers/reports_chunk.py
@@ -21,6 +21,8 @@ Event shape:
 - details_path: Optional S3 URI to details chunk parquet for date inference.
 
 Outputs: parquet, plus reports_chunk_{i}_verbose_sample.json and reports_chunk_{i}_games_sample.csv.
+When tournaments have no original report (page says "updated or replaced"), writes
+reports_chunk_{i}_skipped.json to reports/.
 """
 
 import logging
@@ -32,12 +34,21 @@ from get_tournament_reports import run
 logger = logging.getLogger(__name__)
 
 
-def _derive_sample_paths(output_path: str) -> tuple[str, str]:
-    """Derive sample JSON and CSV paths from output_path (data/ -> sample/)."""
+def _derive_sample_and_reports_paths(output_path: str) -> tuple[str, str, str | None]:
+    """
+    Derive sample JSON, CSV, and reports base from output_path.
+    output_path should contain /data/ (e.g. .../data/tournament_reports_chunks/reports_chunk_0).
+    Returns (sample_json, sample_csv, reports_base) or ("", "", None) if /data/ not present.
+    """
     if "/data/" not in output_path:
-        return "", ""
+        return "", "", None
     sample_base = output_path.replace("/data/", "/sample/", 1)
-    return sample_base + "_verbose_sample.json", sample_base + "_games_sample.csv"
+    reports_base = output_path.replace("/data/", "/reports/", 1)
+    return (
+        sample_base + "_verbose_sample.json",
+        sample_base + "_games_sample.csv",
+        reports_base,
+    )
 
 
 def lambda_handler(event: dict, context) -> dict:
@@ -94,7 +105,9 @@ def lambda_handler(event: dict, context) -> dict:
         f"reports_chunk_{chunk_index}_of_{chunk_count}",
     )
 
-    output_sample_json, output_sample_csv = _derive_sample_paths(output_path)
+    output_sample_json, output_sample_csv, output_reports_base = (
+        _derive_sample_and_reports_paths(output_path)
+    )
 
     games_uri = output_path + "_games.parquet"
     if not override and output_exists(games_uri):
@@ -131,6 +144,7 @@ def lambda_handler(event: dict, context) -> dict:
         save_raw=save_raw,
         output_sample_json=output_sample_json,
         output_sample_csv=output_sample_csv,
+        output_reports_base=output_reports_base,
     )
 
     if exit_code != 0:

--- a/scripts/run_prod_backfill.py
+++ b/scripts/run_prod_backfill.py
@@ -2,9 +2,8 @@
 """
 Run FIDE pipeline Step Function for multiple prod months with controlled concurrency.
 
-Starts executions for each month in [start, end], limiting concurrent runs.
-Polls status and starts new executions when slots open. Logs progress and
-time estimates.
+Starts executions for each month in [start, end] that exists in FIDE's periods API.
+Limits concurrent runs, polls status, and starts new executions when slots open.
 
 Example:
   uv run scripts/run_prod_backfill.py --start 2024-01 --end 2024-12
@@ -23,7 +22,12 @@ from datetime import datetime, timezone
 from typing import Iterator
 
 import boto3
+import requests
 from botocore.exceptions import ClientError
+
+# FIDE periods API (same as pipeline_historical); RUS has long history
+PERIODS_URL = "https://ratings.fide.com/a_tournaments_panel.php"
+REFERENCE_FED = "RUS"
 
 logging.basicConfig(
     level=logging.INFO,
@@ -69,6 +73,37 @@ def month_range(
         if m > 12:
             m = 1
             y += 1
+
+
+def fetch_available_periods() -> list[tuple[int, int]]:
+    """
+    Fetch available (year, month) from FIDE periods API.
+    Returns empty list on failure (caller falls back to unfiltered range).
+    """
+    url = f"{PERIODS_URL}?country={REFERENCE_FED}&periods_tab=1"
+    headers = {"X-Requested-With": "XMLHttpRequest"}
+    try:
+        resp = requests.get(url, headers=headers, timeout=15)
+        if resp.status_code != 200:
+            return []
+        data = resp.json()
+    except Exception:
+        return []
+
+    periods: list[tuple[int, int]] = []
+    for item in data:
+        pub = item.get("frl_publish", "")
+        if not pub:
+            continue
+        parts = pub.split("-")
+        if len(parts) >= 2:
+            try:
+                y, m = int(parts[0]), int(parts[1])
+                if 1 <= m <= 12:
+                    periods.append((y, m))
+            except ValueError:
+                continue
+    return list(set(periods))  # dedupe
 
 
 @dataclass
@@ -139,8 +174,8 @@ def main() -> int:
     parser.add_argument(
         "--max-concurrency",
         type=int,
-        default=10,
-        help="Map state concurrency per execution (default: 10)",
+        default=8,
+        help="Map state concurrency per execution (default: 8)",
     )
     parser.add_argument(
         "--chunk-size",
@@ -160,12 +195,48 @@ def main() -> int:
         return 1
 
     try:
-        months = list(month_range(args.start, args.end))
+        range_months = list(month_range(args.start, args.end))
     except ValueError as e:
         logger.error("%s", e)
         return 1
-    if not months:
+    if not range_months:
         logger.error("No months in range")
+        return 1
+
+    # Fetch FIDE periods and intersect with range; fall back to range if fetch fails
+    available = set(fetch_available_periods())
+    if available:
+        today = datetime.now(timezone.utc).date()
+        months = [
+            (y, m)
+            for (y, m) in range_months
+            if (y, m) in available
+            and (y < today.year or (y == today.year and m <= today.month))
+        ]
+        if months != range_months:
+            excluded = set(range_months) - set(months)
+            logger.info(
+                "FIDE periods: %d in range, %d excluded (not in FIDE or future)",
+                len(months),
+                len(excluded),
+            )
+    else:
+        logger.warning(
+            "Could not fetch FIDE periods; using full range without period filter"
+        )
+        today = datetime.now(timezone.utc).date()
+        months = [
+            (y, m)
+            for (y, m) in range_months
+            if y < today.year or (y == today.year and m <= today.month)
+        ]
+
+    if not months:
+        logger.error(
+            "No months to run (range %04d-%02d to %04d-%02d; none in FIDE periods)",
+            *args.start,
+            *args.end,
+        )
         return 1
 
     logger.info(

--- a/src/scraper/get_tournament_reports.py
+++ b/src/scraper/get_tournament_reports.py
@@ -511,6 +511,18 @@ def fetch_tournament_report(
 
             soup = BeautifulSoup(response.content, "html.parser")
 
+            # Older tournaments may have no original report (no cross table).
+            # Page shows: "Tournament report was updated or replaced, please view
+            # Tournament Details for more information." Skip these.
+            page_text = soup.get_text() if soup else ""
+            if "Tournament report was updated or replaced" in page_text:
+                return (
+                    None,
+                    ERROR_REPORT_UPDATED_OR_REPLACED,
+                    len(attempt_times),
+                    response.content if return_raw else None,
+                )
+
             # Extract "Start: YYYY-MM-DD" from report header for date format inference
             report_start_iso = None
             calc_body = soup.find("div", id="calc_list") or soup
@@ -1269,6 +1281,19 @@ def _write_parquet_to_path(df: pd.DataFrame, path: str) -> None:
     _write_to_path(path, buf.getvalue())
 
 
+ERROR_REPORT_UPDATED_OR_REPLACED = "report_updated_or_replaced"
+
+
+def save_skipped_json(skipped: List[Dict], base_path: str) -> None:
+    """Save tournaments skipped (no original report) to JSON for reporting."""
+    if not skipped:
+        return
+    path = base_path.rstrip("/") + "_skipped.json"
+    content = json.dumps(skipped, indent=2, ensure_ascii=False)
+    _write_to_path(path, content)
+    logger.info("Saved %d skipped (no original report) to %s", len(skipped), path)
+
+
 def save_players_parquet(results: List[Dict], parquet_path: str):
     """Save players Parquet. PK: (player_id, tournament_id)."""
     try:
@@ -1410,6 +1435,7 @@ def run(
     save_raw: bool = True,
     output_sample_json: Optional[str] = None,
     output_sample_csv: Optional[str] = None,
+    output_reports_base: Optional[str] = None,
 ) -> int:
     """
     Scrape tournament reports for codes from input_path, write to output_path.
@@ -1425,6 +1451,7 @@ def run(
         save_raw: If True, save concatenated raw HTML to raw/reports/reports_chunk_{i}.html.gz.
         output_sample_json: Optional path for verbose JSON sample (tournaments with players/rounds).
         output_sample_csv: Optional path for CSV sample from games parquet.
+        output_reports_base: Optional base path for reports (e.g. skipped tournaments JSON).
 
     Returns:
         0 on success, 1 on failure.
@@ -1496,6 +1523,9 @@ def run(
     raw_accumulator: List[Tuple[str, bytes]] = []  # (code, html)
 
     all_results: List[Dict] = []
+    skipped_reports: List[Dict] = (
+        []
+    )  # Tournaments with no original report (updated/replaced)
     success_count = 0
     current_codes = codes
 
@@ -1521,6 +1551,15 @@ def run(
 
         result = {"tournament_code": code}
         if report is None:
+            if error == ERROR_REPORT_UPDATED_OR_REPLACED:
+                # No original report (page says "updated or replaced") - skip, record
+                result["success"] = False
+                result["error"] = error
+                skipped_reports.append({"tournament_code": code, "error": error})
+                all_results.append(result)
+                if pbar:
+                    pbar.update(1)
+                continue
             raise RuntimeError(
                 f"Report fetch failed for tournament {code}: {error or 'unknown'}; "
                 "aborting chunk so Step Function can retry with fresh Lambda"
@@ -1553,6 +1592,9 @@ def run(
 
     save_players_parquet(all_results, players_path)
     save_games_parquet(all_results, games_path, details_map=details_map)
+
+    if output_reports_base and skipped_reports:
+        save_skipped_json(skipped_reports, output_reports_base)
 
     if output_sample_json:
         save_verbose_json_sample(

--- a/tests/fixtures/report_updated_or_replaced_34330.html
+++ b/tests/fixtures/report_updated_or_replaced_34330.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="calc_list">
+  <h2>Original Tournament report</h2>
+  <p>Asian Youth Chp Girls-U12 [34330] (IND, Delhi) Start: <b>2005-12-07</b>
+  <a href="tournament_information.phtml?event=34330">More information and rating report</a>
+  Tournament report was updated or replaced, please view Tournament Details for more information.</p>
+</div>
+</body>
+</html>

--- a/tests/test_get_tournament_reports.py
+++ b/tests/test_get_tournament_reports.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 
 from get_tournament_reports import (
+    ERROR_REPORT_UPDATED_OR_REPLACED,
     extract_forfeit_indicator,
     fetch_tournament_report,
     flatten_result,
@@ -518,6 +519,28 @@ class TestFixtureBasedParsing:
         assert set([g["white_id"], g["black_id"]]) == {"2093596", "24126055"}
         # Niemann won (forfeit +), so if Niemann was white: white_score=1.0, else 0.0
         assert g["white_score"] in (0.0, 1.0)
+
+    def test_report_updated_or_replaced_returns_skip_error(self):
+        """
+        When page has "Tournament report was updated or replaced", return error
+        report_updated_or_replaced (no cross table). These tournaments are skipped.
+        """
+        fixture_path = (
+            Path(__file__).parent / "fixtures" / "report_updated_or_replaced_34330.html"
+        )
+        fixture_html = fixture_path.read_bytes()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = fixture_html
+
+        session = MagicMock()
+        session.get.return_value = mock_response
+
+        report, error, _, _ = fetch_tournament_report("34330", session)
+
+        assert report is None
+        assert error == ERROR_REPORT_UPDATED_OR_REPLACED
 
     @pytest.mark.online
     def test_live_fetch_matches_fixture(self):


### PR DESCRIPTION
## What changed

- **Tournament reports**: Tournaments that show "Tournament report was updated or replaced, please view Tournament Details" (no original cross table) are now skipped instead of aborting the chunk. Skipped tournaments are written to `reports/reports_chunk_{i}_skipped.json`.
- **Prod backfill**: Months to run are limited to those returned by FIDE's periods API, intersected with the given `--start` / `--end` range. Future months are excluded. If the API call fails, the script falls back to the full date range.
- **Defaults**: `--max-concurrency` default changed from 10 to 8.

## Why

**No-original-report tournaments**: Older tournaments (often pre-2006) can appear without the original cross table. The FIDE page shows a message instructing users to use Tournament Details instead. Parsing fails because there is no `calc_table`. Previously this caused the reports chunk to abort. Skipping these tournaments keeps the rest of the chunk running and records them for later inspection.

**FIDE periods filter**: Not every calendar month has FIDE data. The periods API (`a_tournaments_panel.php?country=RUS`) lists months with data. Running backfill for months without data is pointless and wastes Step Function executions. RUS is used as reference federation because of its long history.

**Trade-offs**: If the periods API is down, backfill falls back to the unfiltered range so existing workflows still run. Skipped tournaments are stored per chunk; a separate aggregation step would be needed for a global skipped list.