### PR TITLE
feat(pipeline): Reduce FIDE request load and fail fast on tournaments errors

### DIFF
--- a/handlers/details_chunk.py
+++ b/handlers/details_chunk.py
@@ -118,7 +118,7 @@ def lambda_handler(event: dict, context) -> dict:
     exit_code = run(
         input_path=input_path,
         output_path=output_path,
-        rate_limit=0.5,
+        rate_limit=0.33,
         max_retries=3,
         checkpoint=0,
         quiet=False,

--- a/handlers/ensure_run_name.py
+++ b/handlers/ensure_run_name.py
@@ -13,7 +13,7 @@ Event shape (passthrough from execution input):
     "run_name": null,
     "bucket": "fide-glicko",
     "override": false,
-    "max_concurrency": 10,
+    "max_concurrency": 5,
     "chunk_size": 300
 }
 

--- a/handlers/reports_chunk.py
+++ b/handlers/reports_chunk.py
@@ -139,7 +139,7 @@ def lambda_handler(event: dict, context) -> dict:
         input_path=input_path,
         output_path=output_path,
         details_path=details_path,
-        rate_limit=0,
+        rate_limit=0.5,
         quiet=False,
         save_raw=save_raw,
         output_sample_json=output_sample_json,

--- a/handlers/tournaments.py
+++ b/handlers/tournaments.py
@@ -133,12 +133,10 @@ def lambda_handler(event: dict, context) -> dict:
 
     if exit_code != 0:
         logger.error("Tournaments scrape failed with exit code %d", exit_code)
-        return {
-            "statusCode": 500,
-            "success": False,
-            "output_path": ids_uri,
-            "error": "Scrape failed",
-        }
+        raise RuntimeError(
+            f"Tournaments scrape failed for {year}-{month:02d}: one or more federations "
+            "could not be fetched (fail fast)"
+        )
 
     logger.info("Tournaments scrape completed successfully")
     return {

--- a/infra/step-function/README.md
+++ b/infra/step-function/README.md
@@ -65,7 +65,7 @@ aws stepfunctions start-execution \
 - **run_name** – For prod: omit (derived as `YYYY-MM`). For custom: required (e.g. `"backfill-2024-06"`). For test: optional (default `"test"`)
 - **bucket** – S3 bucket (default: fide-glicko)
 - **override** – if true, refetch/overwrite even when cached (default: false)
-- **max_concurrency** – Map state parallelism for chunk processing (default: 10)
+- **max_concurrency** – Map state parallelism for chunk processing (default: 5)
 - **chunk_size** – optional; default 300
 
 ## Check status

--- a/infra/step-function/pipeline.asl.json
+++ b/infra/step-function/pipeline.asl.json
@@ -164,7 +164,7 @@
         "federations.$": "$.federations",
         "tournaments.$": "$.tournaments",
         "parallel_split_player.$": "$.parallel_split_player",
-        "max_concurrency": 10
+        "max_concurrency": 5
       },
       "Next": "MapDetailsAndReports"
     },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,7 +31,7 @@ uv run scripts/run_prod_backfill.py --start 2024-01 --end 2024-03 --dry-run
 | `--region` | AWS region. |
 | `--bucket` | S3 bucket (default: fide-glicko). |
 | `--override` | Pass override=true to pipeline. |
-| `--max-concurrency` | Map concurrency per execution (default: 10). |
+| `--max-concurrency` | Map concurrency per execution (default: 5). |
 | `--chunk-size` | Max tournaments per chunk (default: 300). |
 | `--dry-run` | List months without starting. |
 

--- a/scripts/run_prod_backfill.py
+++ b/scripts/run_prod_backfill.py
@@ -174,8 +174,8 @@ def main() -> int:
     parser.add_argument(
         "--max-concurrency",
         type=int,
-        default=8,
-        help="Map state concurrency per execution (default: 8)",
+        default=5,
+        help="Map state concurrency per execution (default: 5)",
     )
     parser.add_argument(
         "--chunk-size",

--- a/src/scraper/get_tournaments.py
+++ b/src/scraper/get_tournaments.py
@@ -480,7 +480,7 @@ async def scrape_month(
     federations_path: Path,
     output_path: Union[Path, str],
     output_format: str = "ids",
-    max_concurrency: int = 20,
+    max_concurrency: int = 5,
     json_uri: Optional[str] = None,
     max_retries: int = 3,
     retry_delay: float = 1.0,
@@ -552,24 +552,25 @@ async def scrape_month(
 
     # Simple session - no cookie jar needed, curl works without it
     async with aiohttp.ClientSession() as session:
-        tasks = [
+        coros = [
             fetch_federation_tournaments(
                 session, semaphore, code, name, year, month, max_retries, retry_delay
             )
             for code, name in federations
         ]
+        task_objs = [asyncio.create_task(c) for c in coros]
 
-        # Process results as they complete
-        for coro in asyncio.as_completed(tasks):
+        # Process results as they complete; fail fast on first federation error
+        for fut in asyncio.as_completed(task_objs):
             if _shutdown_requested:
                 logger.warning("Shutdown requested, cancelling remaining tasks...")
-                # Cancel remaining tasks
-                for task in tasks:
-                    if not task.done():
-                        task.cancel()
+                for t in task_objs:
+                    if not t.done():
+                        t.cancel()
+                await asyncio.gather(*task_objs, return_exceptions=True)
                 break
 
-            code, name, tournaments, error, raw_text = await coro
+            code, name, tournaments, error, raw_text = await fut
             processed_count += 1
 
             if raw_tournaments_uri and not error and raw_text:
@@ -582,7 +583,17 @@ async def scrape_month(
 
             if error:
                 errors.append(f"{code} ({name}): {error}")
-                logger.warning(f"{code} ({name}): {error}")
+                logger.error(
+                    "Fail fast: %s (%s): %s - cancelling remaining federation requests",
+                    code,
+                    name,
+                    error,
+                )
+                for t in task_objs:
+                    if not t.done():
+                        t.cancel()
+                await asyncio.gather(*task_objs, return_exceptions=True)
+                break
             else:
                 federation_counts[code] = len(tournaments)
                 if tournaments:
@@ -718,7 +729,7 @@ def run(
     federations_s3_uri: Optional[str] = None,
     override: bool = False,
     quiet: bool = False,
-    max_concurrency: int = 20,
+    max_concurrency: int = 5,
     ids_uri: Optional[str] = None,
     json_uri: Optional[str] = None,
 ) -> int:
@@ -850,8 +861,8 @@ def main() -> int:
         "--concurrency",
         "-c",
         type=int,
-        default=10,
-        help="Maximum number of concurrent requests (default: 10)",
+        default=5,
+        help="Maximum number of concurrent requests (default: 5)",
     )
     parser.add_argument(
         "--max-retries",


### PR DESCRIPTION
## What changed
- **Tournaments**: Concurrency reduced 20→5; fail fast on first federation error (cancel remaining, raise so Step Function fails)
- **Details chunk**: Rate limit 0.5→0.33 req/s
- **Reports chunk**: Rate limit 0→0.5 req/s
- **Pipeline Map**: Default max_concurrency 10→5 (pipeline, ensure_run_name, backfill script)
- Docs updated for new defaults

## Why
FIDE is throttling or blocking requests from AWS Lambda—tournaments and details chunks fail with "Connect call failed" and "Timeout" when running in Lambda but work locally. The difference is (1) Lambda uses AWS IPs that FIDE may treat differently, and (2) the pipeline runs many Map iterations in parallel, so total load is much higher than a single local run.

Changes aim to avoid triggering FIDE rate limits:
- Lower concurrency and rate limits to keep request volume below FIDE’s tolerance
- Fail fast on first tournaments error so we don’t waste Lambda time and cost
- Tournaments Lambda now raises on failure so the Step Function correctly fails instead of treating it as success