### PR TITLE
feat(pipeline): Add tournaments timing logs and optional concurrency; slow reports

### DIFF
--- a/handlers/README.md
+++ b/handlers/README.md
@@ -39,13 +39,17 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
   "run_type": "prod",
   "run_name": "2025-03",
   "bucket": "fide-glicko",
-  "override": false
+  "override": false,
+  "tournaments_max_concurrency": null
 }
 ```
 - **year**, **month**: Required
 - **run_type**, **run_name**: run_name comes from EnsureRunName (prod: YYYY-MM; custom: user-provided)
 - **federations_s3_uri**: Optional. Defaults to latest in `{bucket}/federations/data/`
+- **tournaments_max_concurrency**: Optional. Parallel federation HTTP requests (default `1` when omitted/null). Increase (e.g. `3`–`5`) if the step fails with **Sandbox.Timedout** at **900s** (Lambda hard limit). Lower values reduce burst load on FIDE from AWS.
 - Outputs: `{base}/data/tournament_ids.txt`, `{base}/sample/tournament_ids_sample.json`, `{base}/raw/tournaments.json.gz` (raw API JSON, all federations concatenated, gzip-9)
+
+**Tournaments step & 900s timeout:** One Lambda invocation must finish all federations (~200). Standard Lambdas cannot run longer than **900 seconds**. CloudWatch logs include `projected_total_s`, `lambda_remaining_ms`, and warnings when the scrape is on track to exceed the limit. Mitigations: raise **tournaments_max_concurrency** (faster wall clock, more FIDE load), or split work across multiple runs (e.g. custom federation subsets — not built in). For very slow FIDE responses, **merge** / **ECS** would be a larger architectural change.
 
 ### split_ids
 ```json
@@ -94,6 +98,7 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
 - **override**: If true, overwrite existing output (default: false)
 - **save_raw**: If true, save raw HTML to `{base}/raw/reports/reports_chunk_{i}.html.gz` (default: false)
 - **details_path**: Optional. Defaults to `{base}/data/tournament_details_chunks/details_chunk_{i}_of_{n}.parquet`
+- **Rate limit**: Fixed **0.33 requests/s** to FIDE per chunk (reduces load when Map runs multiple chunks in parallel).
 - Outputs: `reports_chunk_{i}_of_{n}_players.parquet`, `reports_chunk_{i}_of_{n}_games.parquet`; `reports_chunk_{i}_of_{n}_verbose_sample.json`, `reports_chunk_{i}_of_{n}_games_sample.csv`; `{base}/reports/reports_chunk_{i}_of_{n}_skipped.json` when any tournaments have no original report (updated/replaced)
 - Orchestrator: use `chunk_index` from each split_ids chunk, pass run_type/run_name from state
 

--- a/handlers/ensure_run_name.py
+++ b/handlers/ensure_run_name.py
@@ -51,4 +51,7 @@ def lambda_handler(event: dict, context) -> dict:
     out.setdefault("bucket", "fide-glicko")
     out.setdefault("override", False)
     out.setdefault("chunk_size", 300)
+    # Optional; Tournaments Lambda uses default 1 if null (avoid JSONPath missing-key errors)
+    if "tournaments_max_concurrency" not in out:
+        out["tournaments_max_concurrency"] = None
     return out

--- a/handlers/reports_chunk.py
+++ b/handlers/reports_chunk.py
@@ -20,6 +20,8 @@ Event shape:
 - save_raw: If true, save raw HTML to raw/reports/reports_chunk_{i}.html.gz (default: true)
 - details_path: Optional S3 URI to details chunk parquet for date inference.
 
+Rate limit: **0.33 req/s** to FIDE (same order of magnitude as details_chunk; lowers burst vs unlimited).
+
 Outputs: parquet, plus reports_chunk_{i}_verbose_sample.json and reports_chunk_{i}_games_sample.csv.
 When tournaments have no original report (page says "updated or replaced"), writes
 reports_chunk_{i}_skipped.json to reports/.
@@ -139,7 +141,7 @@ def lambda_handler(event: dict, context) -> dict:
         input_path=input_path,
         output_path=output_path,
         details_path=details_path,
-        rate_limit=0.5,
+        rate_limit=0.33,
         quiet=False,
         save_raw=save_raw,
         output_sample_json=output_sample_json,

--- a/handlers/tournaments.py
+++ b/handlers/tournaments.py
@@ -18,6 +18,8 @@ Event shape:
 - bucket: S3 bucket (default: fide-glicko)
 - override: If true, overwrite existing output
 - federations_s3_uri: Optional. Defaults to {base}/data/federations.csv
+- tournaments_max_concurrency: Optional int (default 1). Parallel federation requests to FIDE.
+  Increase if Sandbox.Timedout at 900s; lower reduces throttling risk.
 
 Outputs: {base}/data/tournament_ids.txt, {base}/sample/tournament_ids_sample.json,
 {base}/raw/tournaments.json.gz (raw API JSON, all federations concatenated, gzip-9)
@@ -95,14 +97,21 @@ def lambda_handler(event: dict, context) -> dict:
                 "ids_uri": ids_uri,
             }
 
+    tm = event.get("tournaments_max_concurrency")
+    max_concurrency = int(tm) if tm is not None else 1
+    if max_concurrency < 1:
+        max_concurrency = 1
+
     logger.info(
-        "Starting tournaments scrape: year=%s month=%s bucket=%s run_type=%s run_name=%s override=%s -> %s",
+        "Starting tournaments scrape: year=%s month=%s bucket=%s run_type=%s run_name=%s "
+        "override=%s tournaments_max_concurrency=%s -> %s",
         year,
         month,
         bucket,
         run_type,
         run_name,
         override,
+        max_concurrency,
         ids_uri,
     )
 
@@ -129,6 +138,8 @@ def lambda_handler(event: dict, context) -> dict:
         quiet=False,
         ids_uri=ids_uri,
         json_uri=json_uri,
+        max_concurrency=max_concurrency,
+        lambda_context=context,
     )
 
     if exit_code != 0:

--- a/infra/step-function/pipeline.asl.json
+++ b/infra/step-function/pipeline.asl.json
@@ -53,7 +53,8 @@
         "run_type.$": "$.run_type",
         "run_name.$": "$.run_name",
         "bucket.$": "$.bucket",
-        "override.$": "$.override"
+        "override.$": "$.override",
+        "tournaments_max_concurrency.$": "$.tournaments_max_concurrency"
       },
       "ResultPath": "$.tournaments",
       "Retry": [

--- a/scripts/run_prod_backfill.py
+++ b/scripts/run_prod_backfill.py
@@ -178,6 +178,14 @@ def main() -> int:
         help="Map state concurrency per execution (default: 5)",
     )
     parser.add_argument(
+        "--tournaments-max-concurrency",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Tournaments Lambda: parallel federation requests (default: omit = 1). "
+        "Raise if tournaments step hits 900s Sandbox.Timedout",
+    )
+    parser.add_argument(
         "--chunk-size",
         type=int,
         default=None,
@@ -282,6 +290,8 @@ def main() -> int:
         }
         if args.chunk_size is not None:
             input_dict["chunk_size"] = args.chunk_size
+        if args.tournaments_max_concurrency is not None:
+            input_dict["tournaments_max_concurrency"] = args.tournaments_max_concurrency
         try:
             resp = client.start_execution(
                 stateMachineArn=arn,

--- a/src/scraper/README.md
+++ b/src/scraper/README.md
@@ -162,7 +162,7 @@ python src/scraper/get_federations.py --override
 | `--federations` | `-f` | `data/federations.csv` | Path to federations CSV file (relative to repo root) |
 | `--output` | `-o` | `data/tournament_ids/YYYY_MM` | Output file path (relative to repo root) |
 | `--format` | | `ids` | Output format: `ids` for just IDs, `json` for full tournament data |
-| `--concurrency` | `-c` | `10` | Maximum number of concurrent requests |
+| `--concurrency` | `-c` | `1` | Maximum concurrent requests (default 1 for FIDE; raise locally if needed) |
 | `--max-retries` | `-r` | `3` | Maximum number of retries per federation |
 | `--retry-delay` | | `1.0` | Base delay in seconds between retries |
 | `--quiet` | `-q` | `False` | Disable verbose output |
@@ -173,8 +173,8 @@ python src/scraper/get_federations.py --override
 # Scrape tournaments for January 2025
 python src/scraper/get_tournaments.py --year 2025 --month 1
 
-# Higher concurrency for faster scraping
-python src/scraper/get_tournaments.py --year 2025 --month 1 --concurrency 20
+# Higher concurrency for faster scraping (local only; Lambda default is 1)
+python src/scraper/get_tournaments.py --year 2025 --month 1 --concurrency 10
 
 # Custom federations file and output path
 python src/scraper/get_tournaments.py --year 2025 --month 1 --federations custom_data/federations.csv --output custom_data/tournaments.txt

--- a/src/scraper/get_tournaments.py
+++ b/src/scraper/get_tournaments.py
@@ -19,7 +19,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import aiohttp
 
@@ -43,6 +43,23 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
+
+# Lambda hard timeout (ms) — standard functions max at 15 minutes
+_LAMBDA_MAX_MS = 900_000
+
+
+def _lambda_remaining_ms(lambda_context: Optional[Any]) -> Optional[int]:
+    """Best-effort remaining time when running inside AWS Lambda."""
+    if lambda_context is None:
+        return None
+    fn = getattr(lambda_context, "get_remaining_time_in_millis", None)
+    if fn is None or not callable(fn):
+        return None
+    try:
+        return int(fn())
+    except Exception:
+        return None
+
 
 # Global state for graceful shutdown
 _shutdown_requested = False
@@ -480,12 +497,13 @@ async def scrape_month(
     federations_path: Path,
     output_path: Union[Path, str],
     output_format: str = "ids",
-    max_concurrency: int = 5,
+    max_concurrency: int = 1,
     json_uri: Optional[str] = None,
     max_retries: int = 3,
     retry_delay: float = 1.0,
     limit: int = 0,
     save_raw: bool = True,
+    lambda_context: Optional[Any] = None,
 ) -> List[Tournament]:
     """
     Scrape all federations for a given month.
@@ -501,6 +519,7 @@ async def scrape_month(
         retry_delay: Base delay in seconds between retries.
         save_raw: If True and output uses data/tournament_ids.txt structure, save raw
             JSON from all federations concatenated to raw/tournaments.json.gz (gzip-9).
+        lambda_context: Optional AWS Lambda context (for CloudWatch: remaining time, ETA).
 
     Returns:
         List of unique Tournament objects.
@@ -520,6 +539,17 @@ async def scrape_month(
         f"with max concurrency {max_concurrency}"
     )
     start_time = time.time()
+    rem0 = _lambda_remaining_ms(lambda_context)
+    if rem0 is not None:
+        logger.info(
+            "Tournaments timing: lambda_remaining_ms=%s (~%.1f min left at start), "
+            "lambda_max_ms=%s, federations=%d, concurrency=%d",
+            rem0,
+            rem0 / 60_000,
+            _LAMBDA_MAX_MS,
+            len(federations),
+            max_concurrency,
+        )
 
     # Set up signal handlers for graceful shutdown
     _shutdown_state = {
@@ -607,14 +637,35 @@ async def scrape_month(
                 if processed_count > 0:
                     avg_time = elapsed / processed_count
                     remaining = avg_time * (len(federations) - processed_count)
+                    rem_ms = _lambda_remaining_ms(lambda_context)
+                    proj_total_s = (elapsed / processed_count) * len(federations)
                     logger.info(
-                        "[%d/%d (%.1f%%)] Elapsed: %s, Est. remaining: %s",
+                        "[%d/%d (%.1f%%)] Elapsed: %s, Est. remaining: %s, "
+                        "avg_s_per_federation=%.2f, projected_total_s=%.0f%s%s",
                         processed_count,
                         len(federations),
                         progress_pct,
                         format_time(elapsed),
                         format_time(remaining),
+                        avg_time,
+                        proj_total_s,
+                        f", lambda_remaining_ms={rem_ms}" if rem_ms is not None else "",
+                        (
+                            f", risk_timeout_vs_lambda_900s={'yes' if proj_total_s > 780 else 'no'}"
+                        ),
                     )
+                    if proj_total_s > 780:
+                        logger.warning(
+                            "Tournaments: projected_total_s=%.0f may exceed Lambda 900s; "
+                            "raise execution input tournaments_max_concurrency (trade-off: FIDE load)",
+                            proj_total_s,
+                        )
+                    if rem_ms is not None and rem_ms < 120_000:
+                        logger.warning(
+                            "Tournaments: lambda_remaining_ms=%d (~%d min) — may hit Sandbox.Timedout soon",
+                            rem_ms,
+                            max(1, rem_ms // 60_000),
+                        )
 
     # Write concatenated raw JSON from all federations (single file to reduce PUT costs)
     if raw_tournaments_uri and raw_items:
@@ -704,6 +755,15 @@ async def scrape_month(
         print(f"  By time control: {tc_counts}")
     print("=" * 80)
 
+    rem_end = _lambda_remaining_ms(lambda_context)
+    logger.info(
+        "Tournaments scrape finished: elapsed_s=%.1f unique_tournaments=%d federation_errors=%d%s",
+        elapsed,
+        len(unique_tournaments),
+        len(errors),
+        f" lambda_remaining_ms={rem_end}" if rem_end is not None else "",
+    )
+
     return unique_tournaments, len(errors), len(federations)
 
 
@@ -729,9 +789,10 @@ def run(
     federations_s3_uri: Optional[str] = None,
     override: bool = False,
     quiet: bool = False,
-    max_concurrency: int = 5,
+    max_concurrency: int = 1,
     ids_uri: Optional[str] = None,
     json_uri: Optional[str] = None,
+    lambda_context: Optional[Any] = None,
 ) -> int:
     """
     Scrape tournament IDs for a month and write to S3 or local.
@@ -747,6 +808,7 @@ def run(
         max_concurrency: Max concurrent requests.
         ids_uri: Output path for IDs file (overrides bucket/output_prefix when set).
         json_uri: Output path for JSON sample (overrides derivation when set).
+        lambda_context: AWS Lambda context for CloudWatch timing logs (optional).
 
     Returns:
         0 on success, 1 on failure.
@@ -794,6 +856,7 @@ def run(
                 output_format="ids",
                 max_concurrency=max_concurrency,
                 json_uri=json_uri,
+                lambda_context=lambda_context,
             )
         )
         return _scrape_exit_code(n_errors, n_total)
@@ -861,8 +924,8 @@ def main() -> int:
         "--concurrency",
         "-c",
         type=int,
-        default=5,
-        help="Maximum number of concurrent requests (default: 5)",
+        default=1,
+        help="Maximum number of concurrent requests (default: 1; use higher for local only if FIDE allows)",
     )
     parser.add_argument(
         "--max-retries",


### PR DESCRIPTION
### What changed
- **Tournaments:** Default federation concurrency **1**; optional **`tournaments_max_concurrency`** on execution input (EnsureRunName always sets the key to `null` when omitted; Step Function passes it into the Tournaments task); **CloudWatch** logs for Lambda remaining time, projected total duration, and warnings near the **900s** cap.
- **Reports chunk:** Rate limit **0.5 → 0.33** req/s to FIDE; README notes.
- **Backfill:** `--tournaments-max-concurrency` to pass through when set.
- **Docs:** `handlers/README.md` and `src/scraper/README.md` updated for the above.

### Why
FIDE scraping from Lambda often hits **connect timeouts**, **Map fanout** load, and **tournaments** hitting **Sandbox.Timedout** at **900s**. Lower default federation concurrency reduces burst traffic to FIDE; **optional** `tournaments_max_concurrency` avoids redeploys when you need more parallelism to finish under 900s. **Reports** were throttled by **rate limit** instead of lowering Map concurrency again (user preference). **Structured timing logs** make CloudWatch the place to see whether a run is on track to time out or run out of Lambda budget.

### How
- `get_tournaments.run()` / `scrape_month()` accept optional **`lambda_context`**; log **`lambda_remaining_ms`**, **`projected_total_s`**, **`risk_timeout_vs_lambda_900s`**, and completion summary.
- **`handlers/tournaments.py`** reads **`tournaments_max_concurrency`** (default **1**), passes **`max_concurrency`** and **`context`** into **`run()`**.
- **`pipeline.asl.json`** adds **`tournaments_max_concurrency.$`** to **`Parameters`** for the Tournaments state.
- **`reports_chunk`** handler uses **`rate_limit=0.33`**.

### Testing
Not run in this session; **`pytest`** for touched modules recommended before merge (e.g. **`tests/test_get_tournaments.py`**, **`tests/test_lambda_imports.py`**). Redeploy **EnsureRunName**, **Tournaments**, **reports** Docker image, and **state machine** for the change.

### Notes / Follow-ups
- **Tournaments** at **concurrency 1** can still approach **900s** if FIDE is slow; use **`tournaments_max_concurrency`** or **execution input** in backfill when needed.
- **Reports** image must be redeployed for **0.33** req/s to apply in Lambda.