### PR TITLE
Feat(pipeline): Add SSM defaults and configurable chunk rate limits

### DIFF
--- a/handlers/README.md
+++ b/handlers/README.md
@@ -17,6 +17,7 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
 }
 ```
 - Normalizes `run_name` before pipeline: prod = `{year}-{month:02d}`, custom = required, test = `"test"`
+- In **Lambda only**, merges optional keys from SSM (`PIPELINE_CONFIG_SSM_PARAM`) when omitted from input (see [step-function README](../infra/step-function/README.md)).
 - Returns full passthrough with `run_name` set. Called first by the Step Function.
 
 ### federations
@@ -75,11 +76,13 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
   "run_name": "2024-01",
   "chunk_index": 0,
   "bucket": "fide-glicko",
-  "override": false
+  "override": false,
+  "details_rate_limit": 0.33
 }
 ```
 - **chunk_index**: Required (0-based). **chunk_count**: Required. Paths: `{base}/data/tournament_id_chunks/ids_chunk_{i}_of_{n}.txt` → `{base}/data/tournament_details_chunks/details_chunk_{i}_of_{n}.parquet`
 - **override**: If true, overwrite existing output (default: false)
+- **details_rate_limit**: FIDE requests per second (default **0.33**; **0** = unlimited). Set on execution input / SSM (Lambda) or pass from Step Functions state.
 - **save_raw**: If true, save raw HTML to `{base}/raw/details/details_chunk_{i}_of_{n}.html.gz` (default: false)
 - Orchestrator: use `chunk_index` from each split_ids chunk, pass run_type/run_name from state
 
@@ -91,14 +94,15 @@ All Lambdas accept **run_type**, **run_name**, **bucket**, **override** where ap
   "chunk_index": 0,
   "bucket": "fide-glicko",
   "override": false,
-  "save_raw": false
+  "save_raw": false,
+  "reports_rate_limit": 0.33
 }
 ```
 - **chunk_index**: Required (0-based). **chunk_count**: Required. Paths: `{base}/data/tournament_id_chunks/ids_chunk_{i}_of_{n}.txt` → `{base}/data/tournament_reports_chunks/reports_chunk_{i}_of_{n}_*.parquet`
 - **override**: If true, overwrite existing output (default: false)
 - **save_raw**: If true, save raw HTML to `{base}/raw/reports/reports_chunk_{i}.html.gz` (default: false)
 - **details_path**: Optional. Defaults to `{base}/data/tournament_details_chunks/details_chunk_{i}_of_{n}.parquet`
-- **Rate limit**: Fixed **0.33 requests/s** to FIDE per chunk (reduces load when Map runs multiple chunks in parallel).
+- **reports_rate_limit**: FIDE requests per second (default **0.33**; **0** = unlimited). Set on execution input / SSM (Lambda) or pass from Step Functions state.
 - Outputs: `reports_chunk_{i}_of_{n}_players.parquet`, `reports_chunk_{i}_of_{n}_games.parquet`; `reports_chunk_{i}_of_{n}_verbose_sample.json`, `reports_chunk_{i}_of_{n}_games_sample.csv`; `{base}/reports/reports_chunk_{i}_of_{n}_skipped.json` when any tournaments have no original report (updated/replaced)
 - Orchestrator: use `chunk_index` from each split_ids chunk, pass run_type/run_name from state
 

--- a/handlers/details_chunk.py
+++ b/handlers/details_chunk.py
@@ -17,6 +17,7 @@ Event shape:
 - bucket: S3 bucket (default: fide-glicko)
 - override: If true, overwrite existing output (default: false)
 - save_raw: If true, save raw HTML to raw/details/details_chunk_{i}.html.gz (default: true)
+- details_rate_limit: Requests per second to FIDE (default: 0.33; 0 = unlimited)
 """
 
 import logging
@@ -26,6 +27,17 @@ from s3_io import build_s3_uri_for_run, output_exists
 from get_tournament_details import run
 
 logger = logging.getLogger(__name__)
+
+
+def _rate_limit_req_s(event: dict, key: str, default: float) -> float:
+    v = event.get(key, default)
+    if v is None:
+        return default
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return default
+    return f if f >= 0 else default
 
 
 def _derive_sample_and_reports_paths(output_path: str) -> tuple[str | None, str | None]:
@@ -52,6 +64,7 @@ def lambda_handler(event: dict, context) -> dict:
     bucket = event.get("bucket", "fide-glicko")
     override = event.get("override", False)
     save_raw = event.get("save_raw", True)
+    rate_limit = _rate_limit_req_s(event, "details_rate_limit", 0.33)
 
     if run_type not in ("prod", "custom", "test"):
         return {
@@ -118,7 +131,7 @@ def lambda_handler(event: dict, context) -> dict:
     exit_code = run(
         input_path=input_path,
         output_path=output_path,
-        rate_limit=0.33,
+        rate_limit=rate_limit,
         max_retries=3,
         checkpoint=0,
         quiet=False,

--- a/handlers/ensure_run_name.py
+++ b/handlers/ensure_run_name.py
@@ -5,6 +5,12 @@ For prod: run_name is always derived from year-month (YYYY-MM) to avoid repeat r
 For custom: run_name is required (user-defined).
 For test: run_name defaults to "test" when omitted.
 
+When the handler runs in **AWS Lambda** (Step Functions), optional tuning is
+merged from SSM (``PIPELINE_CONFIG_SSM_PARAM``) for any key omitted from the
+execution input: chunk_size, max_concurrency, tournaments_max_concurrency,
+details_rate_limit, reports_rate_limit. Local runs do not read SSM.
+Precedence: execution input > SSM JSON > code defaults below.
+
 Event shape (passthrough from execution input):
 {
     "year": 2025,
@@ -14,17 +20,22 @@ Event shape (passthrough from execution input):
     "bucket": "fide-glicko",
     "override": false,
     "max_concurrency": 5,
-    "chunk_size": 300
+    "chunk_size": 300,
+    "details_rate_limit": 0.33,
+    "reports_rate_limit": 0.33
 }
 
 Returns the same input with run_name set. Fails with 400 if validation fails.
 """
+
+from .pipeline_ssm import load_pipeline_config_from_ssm
 
 
 def lambda_handler(event: dict, context) -> dict:
     """Normalize run_name and return full passthrough for pipeline."""
     # Step Function passes full state as {"input": {...}}
     data = event.get("input", event)
+    raw_keys = set(data.keys())
     run_type = data.get("run_type", "custom")
     run_name = data.get("run_name")
     year = data.get("year")
@@ -47,10 +58,19 @@ def lambda_handler(event: dict, context) -> dict:
 
     out = dict(data)
     out["run_name"] = run_name
-    # Apply defaults for optional fields
+
+    ssm_config = load_pipeline_config_from_ssm()
+    for key, value in ssm_config.items():
+        if key not in raw_keys:
+            out[key] = value
+
+    # Apply defaults for optional fields (SSM and execution may omit keys)
     out.setdefault("bucket", "fide-glicko")
     out.setdefault("override", False)
     out.setdefault("chunk_size", 300)
+    out.setdefault("max_concurrency", 5)
+    out.setdefault("details_rate_limit", 0.33)
+    out.setdefault("reports_rate_limit", 0.33)
     # Optional; Tournaments Lambda uses default 1 if null (avoid JSONPath missing-key errors)
     if "tournaments_max_concurrency" not in out:
         out["tournaments_max_concurrency"] = None

--- a/handlers/pipeline_ssm.py
+++ b/handlers/pipeline_ssm.py
@@ -1,0 +1,73 @@
+"""Load optional pipeline tuning from SSM Parameter Store (JSON object).
+
+Only used when this code runs inside **AWS Lambda** (e.g. EnsureRunName in Step
+Functions). Local scripts and tests do not set ``AWS_LAMBDA_FUNCTION_NAME``, so
+SSM is never read and boto3 is not required for configuration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+# Keys merged from SSM when not set on the execution input (see ensure_run_name).
+PIPELINE_CONFIG_KEYS = (
+    "chunk_size",
+    "max_concurrency",
+    "tournaments_max_concurrency",
+    "details_rate_limit",
+    "reports_rate_limit",
+)
+
+_ssm_client = None
+
+
+def _get_ssm_client():
+    global _ssm_client
+    if _ssm_client is None:
+        _ssm_client = boto3.client("ssm")
+    return _ssm_client
+
+
+def load_pipeline_config_from_ssm() -> dict[str, Any]:
+    """
+    Read JSON from PIPELINE_CONFIG_SSM_PARAM (String parameter).
+
+    Returns {} unless running in Lambda (``AWS_LAMBDA_FUNCTION_NAME`` is set).
+    Also returns {} if the parameter name env is unset, parameter is missing, or
+    the filtered object is empty. Raises ValueError if the parameter exists but
+    JSON is invalid.
+    """
+    if not os.environ.get("AWS_LAMBDA_FUNCTION_NAME"):
+        return {}
+    name = os.environ.get("PIPELINE_CONFIG_SSM_PARAM", "").strip()
+    if not name:
+        return {}
+    try:
+        resp = _get_ssm_client().get_parameter(Name=name)
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "")
+        if code == "ParameterNotFound":
+            logger.info(
+                "SSM pipeline config not found at %s; using code defaults", name
+            )
+            return {}
+        logger.exception("Failed to read SSM parameter %s", name)
+        raise
+    raw = resp["Parameter"]["Value"]
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"SSM parameter {name} must contain valid JSON object: {e}"
+        ) from e
+    if not isinstance(data, dict):
+        raise ValueError(f"SSM parameter {name} must be a JSON object")
+    return {k: data[k] for k in PIPELINE_CONFIG_KEYS if k in data}

--- a/handlers/reports_chunk.py
+++ b/handlers/reports_chunk.py
@@ -19,8 +19,7 @@ Event shape:
 - override: If true, overwrite existing output (default: false)
 - save_raw: If true, save raw HTML to raw/reports/reports_chunk_{i}.html.gz (default: true)
 - details_path: Optional S3 URI to details chunk parquet for date inference.
-
-Rate limit: **0.33 req/s** to FIDE (same order of magnitude as details_chunk; lowers burst vs unlimited).
+- reports_rate_limit: Requests per second to FIDE (default: 0.33; 0 = unlimited)
 
 Outputs: parquet, plus reports_chunk_{i}_verbose_sample.json and reports_chunk_{i}_games_sample.csv.
 When tournaments have no original report (page says "updated or replaced"), writes
@@ -34,6 +33,17 @@ from s3_io import build_s3_uri_for_run, output_exists
 from get_tournament_reports import run
 
 logger = logging.getLogger(__name__)
+
+
+def _rate_limit_req_s(event: dict, key: str, default: float) -> float:
+    v = event.get(key, default)
+    if v is None:
+        return default
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return default
+    return f if f >= 0 else default
 
 
 def _derive_sample_and_reports_paths(output_path: str) -> tuple[str, str, str | None]:
@@ -64,6 +74,7 @@ def lambda_handler(event: dict, context) -> dict:
     override = event.get("override", False)
     save_raw = event.get("save_raw", True)
     details_path = event.get("details_path")
+    rate_limit = _rate_limit_req_s(event, "reports_rate_limit", 0.33)
 
     if run_type not in ("prod", "custom", "test"):
         return {
@@ -141,7 +152,7 @@ def lambda_handler(event: dict, context) -> dict:
         input_path=input_path,
         output_path=output_path,
         details_path=details_path,
-        rate_limit=0.33,
+        rate_limit=rate_limit,
         quiet=False,
         save_raw=save_raw,
         output_sample_json=output_sample_json,

--- a/infra/step-function/README.md
+++ b/infra/step-function/README.md
@@ -8,7 +8,7 @@ Orchestrates the full scraping flow: ensure_run_name → federations → tournam
 1. **Federations** – fetch federation list (shared across runs)
 2. **Tournaments** – fetch tournament IDs per federation
 3. **Parallel** – split_ids and player_list run in parallel (neither depends on the other)
-4. **Map** – each chunk runs details_chunk then reports_chunk (sequential per chunk; MaxConcurrency configurable via input, default 10)
+4. **Map** – each chunk runs details_chunk then reports_chunk (sequential per chunk; MaxConcurrency configurable via input or SSM, default 5)
 5. **MergeChunks** – combine parquet outputs
 6. **Validate** – run validation report
 
@@ -67,6 +67,35 @@ aws stepfunctions start-execution \
 - **override** – if true, refetch/overwrite even when cached (default: false)
 - **max_concurrency** – Map state parallelism for chunk processing (default: 5)
 - **chunk_size** – optional; default 300
+- **tournaments_max_concurrency** – optional parallel federation requests in the tournaments step (default: 1)
+- **details_rate_limit** – requests per second to FIDE for details chunks (default: 0.33; `0` = unlimited)
+- **reports_rate_limit** – requests per second to FIDE for reports chunks (default: 0.33; `0` = unlimited)
+
+### Semi-permanent defaults (SSM, no redeploy)
+
+The **EnsureRunName** Lambda (only when invoked by Step Functions in AWS) reads a JSON object from **Systems Manager → Parameter Store** so you can tune defaults in the AWS Console (or CLI) without a Git commit. **SSM is not read** when running handlers locally or when building execution input from scripts such as `scripts/run_prod_backfill.py`—pass keys in `--input` / CLI flags instead. Stack parameter **`PipelineConfigSsmParam`** (default: `/fide-glicko/pipeline/config`) sets the parameter **name**; create the String parameter once if it does not exist.
+
+**Precedence:** execution input (above) overrides SSM; SSM overrides code defaults.
+
+Example parameter value:
+
+```json
+{
+  "chunk_size": 300,
+  "max_concurrency": 5,
+  "tournaments_max_concurrency": 2,
+  "details_rate_limit": 0.33,
+  "reports_rate_limit": 0.33
+}
+```
+
+Omit a key from the JSON to fall back to code defaults for that key. Omit a key from **both** the execution input and the JSON to use the code default.
+
+```bash
+aws ssm put-parameter --name /fide-glicko/pipeline/config --type String \
+  --value '{"chunk_size":200,"max_concurrency":8,"details_rate_limit":0.4,"reports_rate_limit":0.3}' \
+  --overwrite
+```
 
 ## Check status
 

--- a/infra/step-function/pipeline.asl.json
+++ b/infra/step-function/pipeline.asl.json
@@ -165,6 +165,10 @@
         "federations.$": "$.federations",
         "tournaments.$": "$.tournaments",
         "parallel_split_player.$": "$.parallel_split_player",
+        "chunk_size.$": "$.chunk_size",
+        "tournaments_max_concurrency.$": "$.tournaments_max_concurrency",
+        "details_rate_limit.$": "$.details_rate_limit",
+        "reports_rate_limit.$": "$.reports_rate_limit",
         "max_concurrency": 5
       },
       "Next": "MapDetailsAndReports"
@@ -186,7 +190,9 @@
         "chunk_index.$": "$$.Map.Item.Value.chunk_index",
         "chunk_count.$": "$$.Map.Item.Value.chunk_count",
         "bucket.$": "$$.Execution.Input.bucket",
-        "override.$": "$$.Execution.Input.override"
+        "override.$": "$$.Execution.Input.override",
+        "details_rate_limit.$": "$.details_rate_limit",
+        "reports_rate_limit.$": "$.reports_rate_limit"
       },
       "Iterator": {
         "StartAt": "DetailsChunk",
@@ -200,7 +206,8 @@
               "chunk_index.$": "$.chunk_index",
               "chunk_count.$": "$.chunk_count",
               "bucket.$": "$.bucket",
-              "override.$": "$.override"
+              "override.$": "$.override",
+              "details_rate_limit.$": "$.details_rate_limit"
             },
             "ResultPath": "$.details_result",
             "Retry": [
@@ -246,7 +253,8 @@
               "chunk_count.$": "$.chunk_count",
               "bucket.$": "$.bucket",
               "override.$": "$.override",
-              "save_raw": true
+              "save_raw": true,
+              "reports_rate_limit.$": "$.reports_rate_limit"
             },
             "Retry": [
               {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,7 +32,10 @@ uv run scripts/run_prod_backfill.py --start 2024-01 --end 2024-03 --dry-run
 | `--bucket` | S3 bucket (default: fide-glicko). |
 | `--override` | Pass override=true to pipeline. |
 | `--max-concurrency` | Map concurrency per execution (default: 5). |
-| `--chunk-size` | Max tournaments per chunk (default: 300). |
+| `--tournaments-max-concurrency` | Tournaments step: parallel federation requests (omit = 1). |
+| `--chunk-size` | Max tournaments per chunk (omit = 300 or SSM default). |
+| `--details-rate-limit` | Details chunk FIDE req/s (omit = SSM or pipeline default). |
+| `--reports-rate-limit` | Reports chunk FIDE req/s (omit = SSM or pipeline default). |
 | `--dry-run` | List months without starting. |
 
 ## run_full_pipeline.py

--- a/scripts/run_prod_backfill.py
+++ b/scripts/run_prod_backfill.py
@@ -8,6 +8,7 @@ Limits concurrent runs, polls status, and starts new executions when slots open.
 Example:
   uv run scripts/run_prod_backfill.py --start 2024-01 --end 2024-12
   uv run scripts/run_prod_backfill.py --start 2024-01 --end 2024-06 --concurrency 2
+  uv run scripts/run_prod_backfill.py --start 2024-01 --end 2024-03 --details-rate-limit 0.4 --reports-rate-limit 0.3
 
 Requires AWS credentials (e.g. aws configure). Uses default region unless --region.
 """
@@ -192,6 +193,20 @@ def main() -> int:
         help="Max tournaments per chunk (default: 300; use smaller if reports_chunk times out)",
     )
     parser.add_argument(
+        "--details-rate-limit",
+        type=float,
+        default=None,
+        metavar="REQ_PER_S",
+        help="Details chunk: FIDE requests per second (omit to use SSM or pipeline default)",
+    )
+    parser.add_argument(
+        "--reports-rate-limit",
+        type=float,
+        default=None,
+        metavar="REQ_PER_S",
+        help="Reports chunk: FIDE requests per second (omit to use SSM or pipeline default)",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print months that would run, do not start",
@@ -292,6 +307,10 @@ def main() -> int:
             input_dict["chunk_size"] = args.chunk_size
         if args.tournaments_max_concurrency is not None:
             input_dict["tournaments_max_concurrency"] = args.tournaments_max_concurrency
+        if args.details_rate_limit is not None:
+            input_dict["details_rate_limit"] = args.details_rate_limit
+        if args.reports_rate_limit is not None:
+            input_dict["reports_rate_limit"] = args.reports_rate_limit
         try:
             resp = client.start_execution(
                 stateMachineArn=arn,

--- a/template.yaml
+++ b/template.yaml
@@ -8,6 +8,14 @@ Parameters:
     Default: fide-glicko
     Description: S3 bucket for scraped data and Lambda deployment artifacts
 
+  PipelineConfigSsmParam:
+    Type: String
+    Default: /fide-glicko/pipeline/config
+    Description: >
+      SSM String parameter name (JSON object) for pipeline tuning. Create or edit
+      in AWS Console (Parameter Store) without redeploying. Omitted execution
+      input keys are filled from this object; see infra/step-function/README.md.
+
 Globals:
   Function:
     Timeout: 60
@@ -26,6 +34,15 @@ Resources:
       Timeout: 10
       MemorySize: 128
       Description: Normalize run_name for pipeline (prod=YYYY-MM, custom=required, test=default)
+      Environment:
+        Variables:
+          PIPELINE_CONFIG_SSM_PARAM: !Ref PipelineConfigSsmParam
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParameter
+              Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${PipelineConfigSsmParam}
 
   FederationsFunction:
     Type: AWS::Serverless::Function
@@ -35,7 +52,7 @@ Resources:
       CodeUri: .functions/federations
       Handler: handlers.federations.lambda_handler
       Timeout: 60
-      MemorySize: 256
+      MemorySize: 128
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref DataBucket
@@ -68,7 +85,7 @@ Resources:
         Command:
           - handlers.player_list.lambda_handler
       Timeout: 300
-      MemorySize: 3008
+      MemorySize: 2560
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref DataBucket

--- a/tests/test_pipeline_ssm.py
+++ b/tests/test_pipeline_ssm.py
@@ -1,0 +1,99 @@
+"""Tests for SSM-backed pipeline defaults (ensure_run_name + pipeline_ssm)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import handlers.ensure_run_name as ensure_run_name  # noqa: E402
+
+
+def test_load_ssm_skips_when_env_unset(monkeypatch):
+    monkeypatch.delenv("PIPELINE_CONFIG_SSM_PARAM", raising=False)
+    from handlers.pipeline_ssm import load_pipeline_config_from_ssm
+
+    assert load_pipeline_config_from_ssm() == {}
+
+
+def test_ensure_run_name_applies_ssm_when_key_not_in_input(monkeypatch):
+    monkeypatch.setattr(
+        ensure_run_name,
+        "load_pipeline_config_from_ssm",
+        lambda: {
+            "chunk_size": 150,
+            "max_concurrency": 8,
+            "details_rate_limit": 0.4,
+            "reports_rate_limit": 0.25,
+        },
+    )
+    out = ensure_run_name.lambda_handler(
+        {"input": {"year": 2025, "month": 3, "run_type": "prod"}},
+        None,
+    )
+    assert out["chunk_size"] == 150
+    assert out["max_concurrency"] == 8
+    assert out["details_rate_limit"] == 0.4
+    assert out["reports_rate_limit"] == 0.25
+
+
+def test_ensure_run_name_execution_input_overrides_ssm(monkeypatch):
+    monkeypatch.setattr(
+        ensure_run_name,
+        "load_pipeline_config_from_ssm",
+        lambda: {"chunk_size": 150, "max_concurrency": 10},
+    )
+    out = ensure_run_name.lambda_handler(
+        {
+            "input": {
+                "year": 2025,
+                "month": 3,
+                "run_type": "prod",
+                "chunk_size": 200,
+            }
+        },
+        None,
+    )
+    assert out["chunk_size"] == 200
+    assert out["max_concurrency"] == 10
+
+
+def test_ensure_run_name_code_defaults_when_no_ssm(monkeypatch):
+    monkeypatch.setattr(ensure_run_name, "load_pipeline_config_from_ssm", lambda: {})
+    out = ensure_run_name.lambda_handler(
+        {"input": {"year": 2025, "month": 3, "run_type": "prod"}},
+        None,
+    )
+    assert out["chunk_size"] == 300
+    assert out["max_concurrency"] == 5
+    assert out["details_rate_limit"] == 0.33
+    assert out["reports_rate_limit"] == 0.33
+
+
+def test_load_ssm_skips_without_lambda_env_even_if_param_set(monkeypatch):
+    """SSM is only read in Lambda (Step Functions); not from local scripts."""
+    monkeypatch.setenv("PIPELINE_CONFIG_SSM_PARAM", "/test/config")
+    monkeypatch.delenv("AWS_LAMBDA_FUNCTION_NAME", raising=False)
+    from handlers.pipeline_ssm import load_pipeline_config_from_ssm
+
+    assert load_pipeline_config_from_ssm() == {}
+
+
+def test_load_ssm_invalid_json_raises(monkeypatch):
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "fide-glicko-ensure-run-name")
+    monkeypatch.setenv("PIPELINE_CONFIG_SSM_PARAM", "/test/config")
+
+    class FakeSSM:
+        def get_parameter(self, Name: str):
+            return {"Parameter": {"Value": "not json"}}
+
+    monkeypatch.setattr("handlers.pipeline_ssm._get_ssm_client", lambda: FakeSSM())
+
+    from handlers.pipeline_ssm import load_pipeline_config_from_ssm
+
+    with pytest.raises(ValueError, match="valid JSON"):
+        load_pipeline_config_from_ssm()


### PR DESCRIPTION
## What changed
Summary of the changes. Tip: feed `git diff --staged` to an AI if you want help writing this.

- **SSM-backed pipeline tuning (Lambda only):** New `handlers/pipeline_ssm.py` reads a JSON String parameter (`PipelineConfigSsmParam`, default `/fide-glicko/pipeline/config`) for `chunk_size`, `max_concurrency`, `tournaments_max_concurrency`, `details_rate_limit`, and `reports_rate_limit` when those keys are omitted from Step Functions execution input. Reading SSM is gated on `AWS_LAMBDA_FUNCTION_NAME` so local scripts never call Parameter Store.
- **`ensure_run_name`:** Merges SSM values, then applies code defaults (including `max_concurrency`, `details_rate_limit`, `reports_rate_limit`). Precedence: execution input > SSM > defaults.
- **Chunk Lambdas:** `details_chunk` and `reports_chunk` take `details_rate_limit` / `reports_rate_limit` from the event (default 0.33 req/s; 0 = unlimited).
- **Step Functions:** ASL passes rate limits through the Map `ItemSelector` and chunk task parameters; `EnsureMaxConcurrency` Pass preserves the new fields.
- **`run_prod_backfill.py`:** Optional `--details-rate-limit` and `--reports-rate-limit` forwarded into execution input when set; docs updated in `scripts/README.md`.
- **SAM:** `PipelineConfigSsmParam`, `PIPELINE_CONFIG_SSM_PARAM` env + `ssm:GetParameter` on EnsureRunName; **FederationsFunction** memory **256→128** MB; **PlayerListFunction** memory **3008→2560** MB.
- **Tests:** `tests/test_pipeline_ssm.py`; docs in `handlers/README.md` and `infra/step-function/README.md`.

## Why
Motivation, design decisions, empirical findings, etc.—anything that'd be useful beyond what someone (or an AI) could infer from the code alone.

Operators wanted to tune chunk size, Map concurrency, tournaments federation parallelism, and per-chunk FIDE rate limits **without a Git commit** for every tweak. **AWS Systems Manager Parameter Store** fits that: editable in the console or CLI, IAM-scoped, no redeploy to change values. **AppConfig** or env-only Lambda settings were heavier or would be overwritten by CloudFormation on deploy; execution-only overrides already existed but did not give a durable default in AWS.

SSM is loaded **only in Lambda** (`AWS_LAMBDA_FUNCTION_NAME`) so `run_prod_backfill` and other local tooling **never** read SSM—they pass overrides via Step Functions input when needed, and omit keys to let the deployed pipeline apply SSM + defaults in **EnsureRunName**. Invalid JSON in the parameter fails the first step so misconfiguration is visible.

The federations and player_list memory adjustments in `template.yaml` are included in this change as staged; confirm they match intended right-sizing vs the main SSM/rate-limit work.

## How
High-level summary of the implementation (keep brief — the code speaks for itself).

EnsureRunName loads filtered JSON from SSM (when in Lambda), merges only for keys absent from the raw execution payload, then `setdefault`s code fallbacks. The state machine threads `details_rate_limit` / `reports_rate_limit` into the Map iterator and chunk tasks. Chunk handlers parse non-negative floats and pass them into existing scraper `run()` calls.

## Testing
What was tested, how, and any notable results.

- `python -m pytest tests/test_pipeline_ssm.py` (and previously `tests/test_step_function.py` in session): merge precedence, skip SSM outside Lambda, invalid JSON raises `ValueError`.
- `sam validate` against `template.yaml` succeeded in development.

## Notes / Follow-ups
Optional: known limitations, deferred work, things a reviewer should pay special attention to.

- Step Functions **Retry** policies in ASL remain unchanged; only runtime tunables listed above are SSM-backed.