### PR TITLE
Chore(infra): Add fideglicko ECR repos, lifecycle policy, and ensure script

### DIFF
--- a/.github/workflows/deploy-sam.yml
+++ b/.github/workflows/deploy-sam.yml
@@ -83,6 +83,10 @@ jobs:
       - name: Prepare per-function directories
         run: bash scripts/prepare_functions.sh
 
+      - name: Ensure ECR repositories exist
+        if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event.inputs.deploy == 'true'
+        run: bash scripts/ensure_ecr_repos.sh
+
       - name: SAM build
         run: sam build --cached
 

--- a/infra/ecr-lifecycle-policy.json
+++ b/infra/ecr-lifecycle-policy.json
@@ -1,0 +1,16 @@
+{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "When more than one image exists, remove the oldest until one remains. A single image is never expired (safe if you stop deploying indefinitely).",
+      "selection": {
+        "tagStatus": "any",
+        "countType": "imageCountMoreThan",
+        "countNumber": 1
+      },
+      "action": {
+        "type": "expire"
+      }
+    }
+  ]
+}

--- a/infra/github-deploy-policy.json
+++ b/infra/github-deploy-policy.json
@@ -110,6 +110,8 @@
         "ecr:CreateRepository",
         "ecr:DescribeRepositories",
         "ecr:DescribeImages",
+        "ecr:GetLifecyclePolicy",
+        "ecr:PutLifecyclePolicy",
         "ecr:BatchCheckLayerAvailability",
         "ecr:InitiateLayerUpload",
         "ecr:UploadLayerPart",

--- a/infra/github-deploy-policy.json
+++ b/infra/github-deploy-policy.json
@@ -5,7 +5,7 @@
       "Sid": "SyncPolicy",
       "Effect": "Allow",
       "Action": "iam:PutRolePolicy",
-      "Resource": "arn:aws:iam::710271917035:policy/fide-glicko-github-deploy"
+      "Resource": "arn:aws:iam::710271917035:role/github-fide-glicko-deploy"
     },
     {
       "Sid": "CloudFormation",
@@ -93,7 +93,10 @@
         "iam:TagRole",
         "iam:UntagRole"
       ],
-      "Resource": "arn:aws:iam::710271917035:role/fide-glicko-*"
+      "Resource": [
+        "arn:aws:iam::710271917035:role/fide-glicko-*",
+        "arn:aws:iam::710271917035:role/github-fide-glicko-deploy"
+      ]
     },
     {
       "Sid": "ECR",

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -3,6 +3,9 @@
 #
 # resolve_s3=false and resolve_image_repos=false bypass the managed stack
 # (aws-sam-cli-managed-default) to avoid "InitialCreation" errors in CI.
+#
+# Image repos: readable names under fideglicko/* (see scripts/ensure_ecr_repos.sh).
+# Replace ACCOUNT/REGION in URIs if you deploy from another account/region.
 version = 0.1
 
 [default.deploy.parameters]
@@ -11,11 +14,11 @@ resolve_s3 = false
 s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-2kqs2vt0rs5c"
 resolve_image_repos = false
 image_repositories = [
-  "PlayerListFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko327ae736/playerlistfunctionbe35717crepo",
-  "DetailsChunkFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko327ae736/detailschunkfunction7fddf1b8repo",
-  "ReportsChunkFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko327ae736/reportschunkfunctionce85551erepo",
-  "MergeChunksFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko327ae736/mergechunksfunctione49a84d4repo",
-  "ValidateFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko327ae736/validatefunctioneddf4248repo"
+  "PlayerListFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/player-list",
+  "DetailsChunkFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/details-chunk",
+  "ReportsChunkFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/reports-chunk",
+  "MergeChunksFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/merge-chunks",
+  "ValidateFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/validate"
 ]
 capabilities = "CAPABILITY_IAM"
 parameter_overrides = []

--- a/scripts/ensure_ecr_repos.sh
+++ b/scripts/ensure_ecr_repos.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Create ECR repositories for SAM image-based Lambdas (names must match samconfig.toml).
+# Apply lifecycle policy from infra/ecr-lifecycle-policy.json.
+# Policy: only when 2+ images exist, expire oldest until one remains. One image per repo is kept
+# forever (no time limit), so Lambdas still work after you stop deploying.
+# Run once per account/region before the first deploy that uses these URIs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REGION="${AWS_REGION:-us-east-1}"
+POLICY_FILE="$REPO_ROOT/infra/ecr-lifecycle-policy.json"
+
+REPOS=(
+  "fideglicko/player-list"
+  "fideglicko/details-chunk"
+  "fideglicko/reports-chunk"
+  "fideglicko/merge-chunks"
+  "fideglicko/validate"
+)
+
+for name in "${REPOS[@]}"; do
+  if aws ecr describe-repositories --repository-names "$name" --region "$REGION" &>/dev/null; then
+    echo "exists: $name"
+  else
+    echo "creating: $name"
+    aws ecr create-repository --repository-name "$name" --region "$REGION" >/dev/null
+  fi
+  aws ecr put-lifecycle-policy \
+    --repository-name "$name" \
+    --region "$REGION" \
+    --lifecycle-policy-text "file://${POLICY_FILE}" >/dev/null
+  echo "lifecycle policy applied: $name"
+done
+
+echo "Done. Repos are ready for sam deploy."


### PR DESCRIPTION
## What changed
- Point SAM `image_repositories` at readable ECR names under `fideglicko/*` (player-list, details-chunk, reports-chunk, merge-chunks, validate) instead of SAM-generated repository names.
- Add `scripts/ensure_ecr_repos.sh` to create those repositories if missing and apply `infra/ecr-lifecycle-policy.json` on every run.
- Lifecycle policy: when more than one image exists in a repo, expire the oldest until one remains; a single image is never removed by this rule.
- Extend the GitHub deploy IAM policy with `ecr:GetLifecyclePolicy` and `ecr:PutLifecyclePolicy`.
- Run the ensure script in `.github/workflows/deploy-sam.yml` before `sam build`.

## Why
SAM-generated ECR repository names were hard to read and made it harder to reason about storage and cleanup. Using a fixed `fideglicko/*` layout matches how the project is named and keeps Cost Explorer and the ECR console understandable.

A time-based lifecycle rule (for example “older than seven days”) would eventually delete the **only** image left after you stop deploying, which can break Lambda cold starts. A **count-based** rule (`imageCountMoreThan` with `countNumber: 1`) only trims when there are **two or more** images, so the last pushed image per repo can remain indefinitely while still dropping older digests after new deploys (evaluation is periodic, not instant on push).

Repos must exist before `sam deploy` pushes images; the script and CI step avoid missing-repo failures and keep the lifecycle policy in sync with the repo. The deploy role needs explicit ECR lifecycle permissions so CI can apply the policy. Source remains in Git; images are reproducible with `sam build` / `sam deploy` if a registry image is gone.