### PR TITLE
Chore(infra): Consolidate ECR repo, add Lambda pull policy, rename image Lambdas

### DIFF
--- a/infra/ecr-lambda-pull-policy.json
+++ b/infra/ecr-lambda-pull-policy.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "LambdaECRImageRetrievalPolicy",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": [
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer"
+      ],
+      "Condition": {
+        "ArnLike": {
+          "aws:sourceArn": "arn:aws:lambda:__REGION__:__ACCOUNT__:function:*"
+        }
+      }
+    }
+  ]
+}

--- a/infra/github-deploy-policy.json
+++ b/infra/github-deploy-policy.json
@@ -113,6 +113,8 @@
         "ecr:CreateRepository",
         "ecr:DescribeRepositories",
         "ecr:DescribeImages",
+        "ecr:GetRepositoryPolicy",
+        "ecr:SetRepositoryPolicy",
         "ecr:GetLifecyclePolicy",
         "ecr:PutLifecyclePolicy",
         "ecr:BatchCheckLayerAvailability",

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -4,8 +4,8 @@
 # resolve_s3=false and resolve_image_repos=false bypass the managed stack
 # (aws-sam-cli-managed-default) to avoid "InitialCreation" errors in CI.
 #
-# Image repos: readable names under fideglicko/* (see scripts/ensure_ecr_repos.sh).
-# Replace ACCOUNT/REGION in URIs if you deploy from another account/region.
+# One shared ECR repo; image tag is SAM's build label (e.g. lambdaimage-<hash>-data from logical ID LambdaImage).
+# See scripts/ensure_ecr_repos.sh. Replace ACCOUNT/REGION in URIs if you deploy elsewhere.
 version = 0.1
 
 [default.deploy.parameters]
@@ -14,11 +14,11 @@ resolve_s3 = false
 s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-2kqs2vt0rs5c"
 resolve_image_repos = false
 image_repositories = [
-  "PlayerListFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/player-list",
-  "DetailsChunkFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/details-chunk",
-  "ReportsChunkFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/reports-chunk",
-  "MergeChunksFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/merge-chunks",
-  "ValidateFunction=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/validate"
+  "LambdaImage=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/lambda-data",
+  "LambdaImageDetailsChunk=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/lambda-data",
+  "LambdaImageReportsChunk=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/lambda-data",
+  "LambdaImageMergeChunks=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/lambda-data",
+  "LambdaImageValidate=710271917035.dkr.ecr.us-east-1.amazonaws.com/fideglicko/lambda-data"
 ]
 capabilities = "CAPABILITY_IAM"
 parameter_overrides = []

--- a/scripts/bootstrap_github_deploy_policy.sh
+++ b/scripts/bootstrap_github_deploy_policy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# One-time bootstrap: attach infra/github-deploy-policy.json as inline policy "GithubDeploy"
+# on the GitHub OIDC deploy role, when the role cannot yet update itself via CI.
+#
+# After this, every "Sync deploy policy from repo" step in .github/workflows/deploy-sam.yml
+# keeps the same document in sync from the repo (no manual runs needed for routine changes).
+#
+# Requires: AWS credentials allowed to call iam:PutRolePolicy on the target role (e.g. console admin).
+#
+# Usage:
+#   AWS_PROFILE=your-admin-profile bash scripts/bootstrap_github_deploy_policy.sh
+#   GITHUB_DEPLOY_ROLE_NAME=my-role-name bash scripts/bootstrap_github_deploy_policy.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROLE_NAME="${GITHUB_DEPLOY_ROLE_NAME:-github-fide-glicko-deploy}"
+POLICY_DOC="$REPO_ROOT/infra/github-deploy-policy.json"
+
+if [[ ! -f "$POLICY_DOC" ]]; then
+  echo "Missing $POLICY_DOC" >&2
+  exit 1
+fi
+
+aws iam put-role-policy \
+  --role-name "$ROLE_NAME" \
+  --policy-name GithubDeploy \
+  --policy-document "file://${POLICY_DOC}"
+
+echo "OK: inline policy GithubDeploy applied to role $ROLE_NAME"

--- a/scripts/ensure_ecr_repos.sh
+++ b/scripts/ensure_ecr_repos.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Create ECR repositories for SAM image-based Lambdas (names must match samconfig.toml).
+# Create the shared ECR repo for all SAM container Lambdas (name must match samconfig.toml image_repositories).
 # Apply lifecycle policy from infra/ecr-lifecycle-policy.json.
+# Apply repository policy so lambda.amazonaws.com can pull images (required for container Lambdas).
 # Policy: only when 2+ images exist, expire oldest until one remains. One image per repo is kept
 # forever (no time limit), so Lambdas still work after you stop deploying.
 # Run once per account/region before the first deploy that uses these URIs.
@@ -10,13 +11,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 REGION="${AWS_REGION:-us-east-1}"
 POLICY_FILE="$REPO_ROOT/infra/ecr-lifecycle-policy.json"
+PULL_POLICY_TEMPLATE="$REPO_ROOT/infra/ecr-lambda-pull-policy.json"
+# Match samconfig / image_repositories account unless overridden (no sts: call — deploy role may lack it)
+ACCOUNT_ID="${AWS_ACCOUNT_ID:-710271917035}"
+TMP_PULL_POLICY="$(mktemp)"
+trap 'rm -f "$TMP_PULL_POLICY"' EXIT
+
+sed -e "s/__REGION__/${REGION}/g" -e "s/__ACCOUNT__/${ACCOUNT_ID}/g" \
+  "$PULL_POLICY_TEMPLATE" >"$TMP_PULL_POLICY"
 
 REPOS=(
-  "fideglicko/player-list"
-  "fideglicko/details-chunk"
-  "fideglicko/reports-chunk"
-  "fideglicko/merge-chunks"
-  "fideglicko/validate"
+  "fideglicko/lambda-data"
 )
 
 for name in "${REPOS[@]}"; do
@@ -30,7 +35,11 @@ for name in "${REPOS[@]}"; do
     --repository-name "$name" \
     --region "$REGION" \
     --lifecycle-policy-text "file://${POLICY_FILE}" >/dev/null
-  echo "lifecycle policy applied: $name"
+  aws ecr set-repository-policy \
+    --repository-name "$name" \
+    --region "$REGION" \
+    --policy-text "file://${TMP_PULL_POLICY}" >/dev/null
+  echo "lifecycle + Lambda pull policy applied: $name"
 done
 
 echo "Done. Repos are ready for sam deploy."

--- a/template.yaml
+++ b/template.yaml
@@ -72,7 +72,8 @@ Resources:
             BucketName: !Ref DataBucket
       Description: Fetch tournament IDs per federation
 
-  PlayerListFunction:
+  # Shared Docker image: SAM tags builds lambdaimage-<hash>-data (logical ID LambdaImage = first alphabetically in this group).
+  LambdaImage:
     Type: AWS::Serverless::Function
     Metadata:
       DockerContext: .
@@ -91,7 +92,7 @@ Resources:
             BucketName: !Ref DataBucket
       Description: Fetch FIDE player list XML
 
-  DetailsChunkFunction:
+  LambdaImageDetailsChunk:
     Type: AWS::Serverless::Function
     Metadata:
       DockerContext: .
@@ -110,7 +111,7 @@ Resources:
             BucketName: !Ref DataBucket
       Description: Scrape tournament details for a chunk
 
-  ReportsChunkFunction:
+  LambdaImageReportsChunk:
     Type: AWS::Serverless::Function
 
     Metadata:
@@ -130,7 +131,7 @@ Resources:
             BucketName: !Ref DataBucket
       Description: Scrape tournament reports for a chunk
 
-  MergeChunksFunction:
+  LambdaImageMergeChunks:
     Type: AWS::Serverless::Function
     Metadata:
       DockerContext: .
@@ -149,7 +150,7 @@ Resources:
             BucketName: !Ref DataBucket
       Description: Merge detail and report chunks into single parquet files
 
-  ValidateFunction:
+  LambdaImageValidate:
     Type: AWS::Serverless::Function
     Metadata:
       DockerContext: .
@@ -191,12 +192,12 @@ Resources:
         EnsureRunNameFunctionArn: !GetAtt EnsureRunNameFunction.Arn
         FederationsFunctionArn: !GetAtt FederationsFunction.Arn
         TournamentsFunctionArn: !GetAtt TournamentsFunction.Arn
-        PlayerListFunctionArn: !GetAtt PlayerListFunction.Arn
+        PlayerListFunctionArn: !GetAtt LambdaImage.Arn
         SplitIdsFunctionArn: !GetAtt SplitIdsFunction.Arn
-        DetailsChunkFunctionArn: !GetAtt DetailsChunkFunction.Arn
-        ReportsChunkFunctionArn: !GetAtt ReportsChunkFunction.Arn
-        MergeChunksFunctionArn: !GetAtt MergeChunksFunction.Arn
-        ValidateFunctionArn: !GetAtt ValidateFunction.Arn
+        DetailsChunkFunctionArn: !GetAtt LambdaImageDetailsChunk.Arn
+        ReportsChunkFunctionArn: !GetAtt LambdaImageReportsChunk.Arn
+        MergeChunksFunctionArn: !GetAtt LambdaImageMergeChunks.Arn
+        ValidateFunctionArn: !GetAtt LambdaImageValidate.Arn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -206,12 +207,12 @@ Resources:
                 - !GetAtt EnsureRunNameFunction.Arn
                 - !GetAtt FederationsFunction.Arn
                 - !GetAtt TournamentsFunction.Arn
-                - !GetAtt PlayerListFunction.Arn
+                - !GetAtt LambdaImage.Arn
                 - !GetAtt SplitIdsFunction.Arn
-                - !GetAtt DetailsChunkFunction.Arn
-                - !GetAtt ReportsChunkFunction.Arn
-                - !GetAtt MergeChunksFunction.Arn
-                - !GetAtt ValidateFunction.Arn
+                - !GetAtt LambdaImageDetailsChunk.Arn
+                - !GetAtt LambdaImageReportsChunk.Arn
+                - !GetAtt LambdaImageMergeChunks.Arn
+                - !GetAtt LambdaImageValidate.Arn
 
 Outputs:
   PipelineStateMachineArn:


### PR DESCRIPTION
## What changed
- **Single shared ECR repository** `fideglicko/lambda-data`: all five container Lambdas in `samconfig.toml` now map to the same URI instead of five separate `fideglicko/*` repos.
- **`infra/ecr-lambda-pull-policy.json`**: repository policy template allowing `lambda.amazonaws.com` to pull images (`BatchGetImage`, `GetDownloadUrlForLayer`) with `ArnLike` on `aws:sourceArn`; `scripts/ensure_ecr_repos.sh` substitutes region/account, applies it with `ecr set-repository-policy` after create/lifecycle, and only ensures the one shared repo.
- **`infra/github-deploy-policy.json`**: add `ecr:GetRepositoryPolicy` and `ecr:SetRepositoryPolicy` so CI can attach that repository policy.
- **`template.yaml`**: rename container Lambda logical resources to `LambdaImage`, `LambdaImageDetailsChunk`, `LambdaImageReportsChunk`, `LambdaImageMergeChunks`, `LambdaImageValidate`; update Step Functions `!GetAtt` and invoke policy ARNs accordingly (substitution keys for ASL unchanged). `FunctionName` values for the Lambdas are unchanged.
- **`scripts/bootstrap_github_deploy_policy.sh`**: one-shot `iam put-role-policy` to attach `infra/github-deploy-policy.json` as inline `GithubDeploy` when the role cannot self-update yet.

## Why
- **One image, one repo:** All five container functions share one Docker build; pointing them at one ECR repo matches that and avoids misleading paths like `…/reports-chunk` with a tag that reflected a different SAM build label.
- **403 on deploy:** New or manually created repos did not grant Lambda permission to pull images; the repository policy fixes “Lambda does not have permission to access the ECR image.”
- **Tag prefix `lambdaimage-…`:** SAM derives the image tag prefix from the CloudFormation logical ID; renaming the primary shared-image resource to `LambdaImage` yields tags like `lambdaimage-<hash>-data` instead of `playerlistfunction-…`.
- **IAM bootstrap script:** When the GitHub OIDC role could not yet apply updated inline policy, an admin can run the bootstrap script once; after that, routine policy updates stay in-repo and can be synced by CI as before.

## How
- `ensure_ecr_repos.sh` creates `fideglicko/lambda-data` if missing, applies existing lifecycle JSON, then applies the Lambda pull policy from the templated JSON file.
- `samconfig.toml` lists five `image_repositories` entries (one per function logical ID) all targeting the same ECR URI so SAM still maps each function to the shared image store.

## Testing
- `sam validate` (recommended locally on this branch). Full `sam build` / deploy validates ECR + Lambda end-to-end in AWS.

## Notes / Follow-ups
- **Logical ID renames** will cause CloudFormation to **replace** those five Lambda resources in the stack (same `FunctionName` where defined); expect a normal replace-style deploy.
- **Old ECR repositories** (`fideglicko/player-list`, etc.) can be **deleted manually** in the console after a successful deploy to the shared repo to avoid leftover storage/cost.
- Ensure the GitHub deploy role’s inline policy includes the new ECR permissions (sync from repo or run `scripts/bootstrap_github_deploy_policy.sh` once with an admin principal if needed).