### PR TITLE
fix(ci): pre-delete Lambda functions to unblock logical ID rename

### DIFF
--- a/.github/workflows/deploy-sam.yml
+++ b/.github/workflows/deploy-sam.yml
@@ -122,6 +122,29 @@ jobs:
           print('Step Function definition valid (result=OK)')
           "
 
+      - name: Migrate Lambda logical ID rename (one-time, PR #73)
+        if: github.event_name == 'push' || github.event.inputs.deploy == 'true'
+        run: |
+          # PR #73 renamed logical IDs (PlayerListFunction → LambdaImage, etc.) while keeping the
+          # same FunctionNames. CF treats this as delete-old + create-new, but create runs first,
+          # causing a name collision caught by AWS::EarlyValidation::ResourceExistenceCheck.
+          # Pre-delete the functions so CF can recreate them under the new logical IDs.
+          # Safe: CF's Lambda resource handler treats "not found" on delete as success.
+          if aws cloudformation describe-stack-resource \
+              --stack-name fide-glicko \
+              --logical-resource-id PlayerListFunction \
+              --region "${AWS_REGION}" 2>/dev/null; then
+            echo "Old logical IDs detected — deleting Lambda functions to unblock rename..."
+            for func in fide-glicko-player-list fide-glicko-details-chunk fide-glicko-reports-chunk fide-glicko-merge-chunks fide-glicko-validate; do
+              aws lambda delete-function --function-name "$func" --region "${AWS_REGION}" \
+                && echo "Deleted: $func" || echo "Already gone: $func"
+            done
+          else
+            echo "Migration not needed — old logical IDs are gone"
+          fi
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+
       - name: SAM deploy
         if: github.event_name == 'push' || github.event.inputs.deploy == 'true'
         run: sam deploy --no-confirm-changeset


### PR DESCRIPTION
## Problem

After merging PR #73 (which renamed the CloudFormation logical IDs for 5 image-based Lambda functions — e.g. `PlayerListFunction` → `LambdaImage` — while keeping the same explicit `FunctionName` values), all subsequent deploys fail with:

```
Status: FAILED. Reason: The following hook(s)/validation failed:
[AWS::EarlyValidation::ResourceExistenceCheck]
```

**Why**: CloudFormation treats a logical ID rename as *create-new then delete-old*. The `AWS::EarlyValidation::ResourceExistenceCheck` hook fires before the changeset executes and rejects it because the new logical IDs (`LambdaImage`, `LambdaImageDetailsChunk`, etc.) would create Lambda functions that already exist under the old logical IDs — a name collision CF refuses to proceed with.

## Fix

Adds a one-time migration step to `deploy-sam.yml` that runs before `sam deploy`:

1. Checks if `PlayerListFunction` (old logical ID) still exists in the stack
2. If so, deletes the 5 conflicting Lambda functions by name so CloudFormation can recreate them cleanly under the new logical IDs
3. CloudFormation's Lambda resource handler treats "function not found" on delete as success, so the rest of the changeset (removing old logical IDs) completes without error
4. On every future deploy the check returns false — the step is a no-op

## Notes

- Brief Lambda downtime (~seconds) on this one deploy only, during the gap between pre-delete and SAM recreating them
- No data loss — all pipeline data lives in S3, which is unmanaged by this stack
- The migration step self-disables after the first successful deploy