### PR TITLE
Fix(ci): Delete stack for rename migration; add preview and template tests

### DIFF
--- a/.github/workflows/deploy-sam.yml
+++ b/.github/workflows/deploy-sam.yml
@@ -126,22 +126,27 @@ jobs:
         if: github.event_name == 'push' || github.event.inputs.deploy == 'true'
         run: |
           # PR #73 renamed logical IDs (PlayerListFunction → LambdaImage, etc.) while keeping the
-          # same FunctionNames. CF treats this as delete-old + create-new, but create runs first,
-          # causing a name collision caught by AWS::EarlyValidation::ResourceExistenceCheck.
-          # Pre-delete the functions so CF can recreate them under the new logical IDs.
-          # Safe: CF's Lambda resource handler treats "not found" on delete as success.
+          # same FunctionNames. CF tracks physical resource names per logical ID, so it refuses to
+          # create a new resource with a name already owned by the stack under a different ID —
+          # even after the Lambda is deleted from AWS. The only fix is to delete the whole stack
+          # so CF loses its internal ownership records, then SAM recreates everything fresh.
           if aws cloudformation describe-stack-resource \
               --stack-name fide-glicko \
               --logical-resource-id PlayerListFunction \
               --region "${AWS_REGION}" 2>/dev/null; then
-            echo "Old logical IDs detected — deleting Lambda functions to unblock rename..."
-            for func in fide-glicko-player-list fide-glicko-details-chunk fide-glicko-reports-chunk fide-glicko-merge-chunks fide-glicko-validate; do
-              aws lambda delete-function --function-name "$func" --region "${AWS_REGION}" \
-                && echo "Deleted: $func" || echo "Already gone: $func"
-            done
+            echo "Old logical IDs detected — deleting stack for clean rename migration..."
+            aws cloudformation delete-stack --stack-name fide-glicko --region "${AWS_REGION}"
+            aws cloudformation wait stack-delete-complete --stack-name fide-glicko --region "${AWS_REGION}"
+            echo "Stack deleted — SAM will recreate it fresh"
           else
             echo "Migration not needed — old logical IDs are gone"
           fi
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+
+      - name: SAM changeset preview (PR only)
+        if: github.event_name == 'pull_request'
+        run: sam deploy --no-execute-changeset --no-fail-on-empty-changeset
         env:
           AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "tqdm>=4.66.0",
     "pyarrow>=14.0.0",
     "pandas>=2.0.0",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,111 @@
+"""Static validation for template.yaml CloudFormation/SAM template.
+
+Catches deploy failures before they reach CI:
+- Duplicate FunctionName values (two logical IDs cannot share a physical name)
+- FunctionName moved to a new logical ID (rename conflict: CF refuses to create a
+  resource with a name it already owns under a different ID, even mid-changeset)
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE_PATH = REPO_ROOT / "template.yaml"
+LAMBDA_TYPES = {"AWS::Lambda::Function", "AWS::Serverless::Function"}
+
+
+def _cf_constructor(loader: yaml.SafeLoader, tag_suffix: str, node: yaml.Node):
+    """Treat all CloudFormation intrinsic function tags as plain Python values."""
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node, deep=True)
+    return loader.construct_mapping(node, deep=True)
+
+
+def _load_template(text: str) -> dict:
+    loader_cls = type("CFLoader", (yaml.SafeLoader,), {})
+    yaml.add_multi_constructor("!", _cf_constructor, Loader=loader_cls)
+    return yaml.load(text, Loader=loader_cls)
+
+
+def _function_names(template: dict) -> dict[str, str]:
+    """Return {FunctionName: logical_id} for Lambdas with explicit string names."""
+    result = {}
+    for logical_id, resource in template.get("Resources", {}).items():
+        if resource.get("Type") in LAMBDA_TYPES:
+            fn_name = resource.get("Properties", {}).get("FunctionName")
+            if isinstance(fn_name, str):
+                result[fn_name] = logical_id
+    return result
+
+
+def test_no_duplicate_function_names() -> None:
+    """No two logical IDs in the template may use the same FunctionName.
+
+    CloudFormation cannot manage two resources with the same physical name,
+    even temporarily during a changeset.
+    """
+    template = _load_template(TEMPLATE_PATH.read_text())
+    seen: dict[str, str] = {}
+    duplicates: list[str] = []
+    for logical_id, resource in template.get("Resources", {}).items():
+        if resource.get("Type") in LAMBDA_TYPES:
+            fn_name = resource.get("Properties", {}).get("FunctionName")
+            if not isinstance(fn_name, str):
+                continue
+            if fn_name in seen:
+                duplicates.append(
+                    f"  {fn_name!r}: used by both {seen[fn_name]!r} and {logical_id!r}"
+                )
+            else:
+                seen[fn_name] = logical_id
+    assert not duplicates, (
+        "Duplicate FunctionNames in template.yaml — CloudFormation cannot manage two "
+        "resources with the same physical name:\n" + "\n".join(duplicates)
+    )
+
+
+def test_no_function_name_logical_id_rename() -> None:
+    """Detect when a FunctionName is moved from one logical ID to another.
+
+    CloudFormation tracks physical resource names per logical ID. Renaming a
+    logical ID while keeping the same FunctionName causes the changeset to fail
+    with "already exists in stack" because CF tries to create-before-delete and
+    its own internal ownership check rejects the duplicate claim.
+
+    Compares the current template against the previous git commit. Skipped when
+    there is no prior commit (e.g. initial repo setup).
+    """
+    result = subprocess.run(
+        ["git", "show", "HEAD~1:template.yaml"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    if result.returncode != 0:
+        pytest.skip("No previous commit to compare against")
+
+    prev_names = _function_names(_load_template(result.stdout))
+    curr_names = _function_names(_load_template(TEMPLATE_PATH.read_text()))
+
+    renames = {
+        fn_name: (old_lid, new_lid)
+        for fn_name, new_lid in curr_names.items()
+        if fn_name in prev_names and (old_lid := prev_names[fn_name]) != new_lid
+    }
+
+    assert not renames, (
+        "FunctionName → logical ID renames detected in template.yaml.\n"
+        "CloudFormation refuses to create a resource with a name it already owns "
+        "under a different logical ID, even within the same changeset.\n"
+        "Affected FunctionNames (old logical ID → new):\n"
+        + "\n".join(
+            f"  {fn!r}: {old!r} → {new!r}" for fn, (old, new) in renames.items()
+        )
+        + "\n\nTo deploy this rename: delete the CloudFormation stack first, or use "
+        "a two-step deploy (rename FunctionName first, then rename the logical ID)."
+    )


### PR DESCRIPTION
## What changed

- **Deploy workflow (`deploy-sam.yml`):** The one-time migration for PR #73 no longer deletes individual Lambda functions. If the stack still has the old logical ID `PlayerListFunction`, it deletes the **entire** `fide-glicko` CloudFormation stack and waits for deletion to finish, then `sam deploy` recreates the stack. A **SAM changeset preview** step runs on pull requests only: `sam deploy --no-execute-changeset --no-fail-on-empty-changeset`.
- **`pyproject.toml`:** Add `pyyaml>=6.0` for template parsing in tests.
- **`tests/test_template.py`:** New static checks on `template.yaml`: no duplicate `FunctionName` values across Lambda resources, and no `FunctionName` moved to a different logical ID vs `HEAD~1` (with a clear failure message and remediation hints).

## Why

**This is the most important section.** After PR #73 renamed several Lambda logical IDs while keeping the same `FunctionName` values, deploys failed in two ways: first `AWS::EarlyValidation::ResourceExistenceCheck`, then after pre-deleting Lambdas in AWS, CloudFormation still reported `fide-glicko-* already exists in stack`. That happens because CloudFormation tracks physical names per logical ID; deleting the Lambda in AWS does not clear that stack ownership, so create-before-delete in the same changeset still collides. Deleting the whole stack removes CloudFormation’s internal ownership so SAM can create resources under the new logical IDs on a fresh deploy.

Pre-deleting only Lambdas was rejected as insufficient. A PR-only **changeset preview** catches changeset creation failures (including those two classes) before merge to `main`, without applying the stack. **Static template tests** complement that: they flag duplicate names and `FunctionName` ↔ logical ID renames in a commit vs the parent, which is the risky pattern; they do not require AWS. Trade-off: the migration briefly deletes all stack-managed resources (Lambdas, Step Function, IAM roles tied to the stack); pipeline data in S3 is outside the stack and unaffected. Another trade-off: `test_no_function_name_logical_id_rename` compares to `HEAD~1` only, so multi-commit PRs that rename in an earlier commit may not trip the test on the final commit if `template.yaml` did not change again.