### PR TITLE
fix(orchestrator): Move failed month to back of queue on failure

### DIFF
--- a/handlers/orchestrator.py
+++ b/handlers/orchestrator.py
@@ -192,8 +192,12 @@ def lambda_handler(event: dict, context) -> dict:
                     state["deferred_months"].get(exec_month, 0) + 1
                 )
                 fail_count = state["deferred_months"][exec_month]
+                # Move to end of remaining_months so other months run first
+                if exec_month in state["remaining_months"]:
+                    state["remaining_months"].remove(exec_month)
+                    state["remaining_months"].append(exec_month)
                 logger.info(
-                    "Execution %s for %s (failure #%d); deferring to back of queue",
+                    "Execution %s for %s (failure #%d); moved to back of queue",
                     exec_status,
                     exec_month,
                     fail_count,


### PR DESCRIPTION
## Summary
- On failure, the orchestrator incremented `deferred_months[month]` but never updated the position of the month in `remaining_months`
- With `DEFERRED_THRESHOLD=1`, once all remaining months had ≥1 failure, `deferred_queue[0]` always resolved to the same front-of-list month — retrying it indefinitely (2011-07 hit 18 failures in a row)
- Fix: on failure, remove the month from its current position and append it to the end of `remaining_months` so all other months run before it's retried

## Root cause trace
```
remaining_months = ["2011-07", "2011-09", ...]   # 2011-07 stuck at front
deferred_months  = {"2011-07": 18, ...}           # all months deferred
normal_queue = []                                  # empty — all have ≥1 failure
deferred_queue = ["2011-07", "2011-09", ...]       # same order as remaining_months
next_month = deferred_queue[0] = "2011-07"         # forever
```

## Test plan
- [ ] Live state file already patched (2011-07 moved to back manually)
- [ ] Merge and deploy — next orchestrator tick should process 2011-09

🤖 Generated with [Claude Code](https://claude.com/claude-code)