### PR TITLE
fix(tournaments): Treat empty federation filter and 0-fed scrape as failure

### DIFF
--- a/handlers/tournaments.py
+++ b/handlers/tournaments.py
@@ -61,6 +61,12 @@ def _load_federation_filter(bucket: str, year: int, month: int) -> frozenset | N
         codes = frozenset(
             code for code, months in country_months.items() if year_month in months
         )
+        if not codes:
+            logger.warning(
+                "Country-month lookup has no federations for %s; querying all federations",
+                year_month,
+            )
+            return None
         logger.info(
             "Country-month lookup loaded: %d/%d federations have data for %s",
             len(codes),

--- a/src/scraper/get_tournaments.py
+++ b/src/scraper/get_tournaments.py
@@ -783,11 +783,13 @@ def _scrape_exit_code(n_errors: int, n_total: int) -> int:
     """
     Return exit code for scrape outcome.
 
-    - 0: All federations succeeded (or no federations to process).
-    - 1: Any federation failed — fail so we don't use partial/incomplete data.
+    - 0: All federations succeeded.
+    - 1: Any federation failed, or no federations were queried (filter produced empty
+         set or federations list is empty — indicates a configuration problem, not a
+         legitimate empty month).
     """
     if n_total == 0:
-        return 0
+        return 1
     if n_errors > 0:
         return 1
     return 0

--- a/src/scraper/get_tournaments.py
+++ b/src/scraper/get_tournaments.py
@@ -862,7 +862,7 @@ def run(
         return 1
 
     try:
-        _, n_errors, n_total = asyncio.run(
+        tournaments, n_errors, n_total = asyncio.run(
             scrape_month(
                 year,
                 month,
@@ -875,6 +875,13 @@ def run(
                 federation_filter=federation_filter,
             )
         )
+        if n_total > 0 and len(tournaments) == 0 and n_errors == 0:
+            logger.error(
+                "Scraped %d federations with 0 errors but found 0 tournaments — "
+                "FIDE may be blocking or returning empty; failing to avoid writing empty output",
+                n_total,
+            )
+            return 1
         return _scrape_exit_code(n_errors, n_total)
     except Exception as e:
         logger.error("Fatal error: %s", e)


### PR DESCRIPTION
## Summary

Two related bugs that caused empty `tournament_ids.txt` files (1 byte) to be silently written and treated as success, permanently blocking those months from re-scraping.

### Bug 1 — Empty frozenset passes `is not None` check (`handlers/tournaments.py`)

`_load_federation_filter()` returned `frozenset()` when the country-months lookup existed but had no entries for the requested month. An empty frozenset is not `None`, so it passed into `scrape_month()` as the filter, causing every federation to be filtered out: 0 federations queried, 0 IDs, empty file written.

**Fix:** Return `None` when the filter would be empty (falls back to querying all federations).

### Bug 2 — `n_total == 0` treated as success (`src/scraper/get_tournaments.py`)

`_scrape_exit_code(0, 0)` returned 0 (success) with the comment "or no federations to process". This masked the empty-filter scenario as a clean success, causing the Lambda to write a 1-byte file and return `{"success": true}` to Step Functions.

**Fix:** Return exit code 1 when `n_total == 0` — no federations queried means something went wrong, not a legitimate empty month (those are filtered out by the orchestrator's `_active_backfill_months()`).

## Affected months (stale files deleted)

- `2011-07`, `2013-08`, `2014-12`, `2017-04`, `2017-11` — all had 1-byte empty `tournament_ids.txt`; deleted so they re-scrape on next run.

## Test plan
- [ ] `uv run pytest -m "not online"` — all 79 pass
- [ ] Re-enable EventBridge; confirm the above months scrape successfully (RUS alone has 75 tournaments for 2013-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)