### PR TITLE
chore(infra): Reduce player-list/merge-chunks memory, slow orchestrator to 2h

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -86,7 +86,7 @@ Resources:
         Command:
           - handlers.player_list.lambda_handler
       Timeout: 300
-      MemorySize: 2560
+      MemorySize: 512
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref DataBucket
@@ -144,7 +144,7 @@ Resources:
         Command:
           - handlers.merge_chunks.lambda_handler
       Timeout: 300
-      MemorySize: 2048
+      MemorySize: 512
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref DataBucket
@@ -211,7 +211,7 @@ Resources:
         HourlySchedule:
           Type: Schedule
           Properties:
-            Schedule: "rate(1 hour)"
+            Schedule: "rate(2 hours)"
             Description: "Backfill orchestrator — disabled by default, enable manually when ready"
             Enabled: false
 


### PR DESCRIPTION
## Summary

- **player-list**: 2560 MB → 512 MB (peak observed: 212 MB — 92% waste)
- **merge-chunks**: 2048 MB → 512 MB (peak observed: 272 MB — 87% waste)
- **EventBridge**: `rate(1 hour)` → `rate(2 hours)` — most runs take 30–50 min; hourly polling was redundant

## Left unchanged
| Lambda | Allocated | Peak used | Reason |
|--------|-----------|-----------|--------|
| details-chunk | 512 MB | ~450 MB | CPU-bound; 2023-06 runs hit 887s/900s timeout |
| reports-chunk | 1024 MB | 407 MB | CPU-bound; runs hit 670s, slowing rate risks timeouts |
| validate | 1536 MB | 977 MB | Too close to cut safely |

## Notes
- Lambda memory also controls CPU allocation — reducing details-chunk or reports-chunk would slow scraping and cause more 900s timeouts on large months
- The 2h schedule still picks up the next month within 2h of a run completing; no meaningful throughput loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)