### PR TITLE
chore: Reduce chunk size, scraping rates, and Lambda memory

### DIFF
--- a/handlers/ensure_run_name.py
+++ b/handlers/ensure_run_name.py
@@ -67,10 +67,10 @@ def lambda_handler(event: dict, context) -> dict:
     # Apply defaults for optional fields (SSM and execution may omit keys)
     out.setdefault("bucket", "fide-glicko")
     out.setdefault("override", False)
-    out.setdefault("chunk_size", 300)
+    out.setdefault("chunk_size", 175)
     out.setdefault("max_concurrency", 5)
-    out.setdefault("details_rate_limit", 0.33)
-    out.setdefault("reports_rate_limit", 0.33)
+    out.setdefault("details_rate_limit", 0.25)
+    out.setdefault("reports_rate_limit", 0.4)
     # Optional; Tournaments Lambda uses default 1 if null (avoid JSONPath missing-key errors)
     if "tournaments_max_concurrency" not in out:
         out["tournaments_max_concurrency"] = None

--- a/template.yaml
+++ b/template.yaml
@@ -66,7 +66,7 @@ Resources:
       CodeUri: .functions/tournaments
       Handler: handlers.tournaments.lambda_handler
       Timeout: 900
-      MemorySize: 256
+      MemorySize: 192
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref DataBucket
@@ -177,7 +177,7 @@ Resources:
       CodeUri: .functions/split_ids
       Handler: handlers.split_ids.lambda_handler
       Timeout: 120
-      MemorySize: 256
+      MemorySize: 128
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref DataBucket

--- a/tests/test_pipeline_ssm.py
+++ b/tests/test_pipeline_ssm.py
@@ -68,10 +68,10 @@ def test_ensure_run_name_code_defaults_when_no_ssm(monkeypatch):
         {"input": {"year": 2025, "month": 3, "run_type": "prod"}},
         None,
     )
-    assert out["chunk_size"] == 300
+    assert out["chunk_size"] == 175
     assert out["max_concurrency"] == 5
-    assert out["details_rate_limit"] == 0.33
-    assert out["reports_rate_limit"] == 0.33
+    assert out["details_rate_limit"] == 0.25
+    assert out["reports_rate_limit"] == 0.4
 
 
 def test_load_ssm_skips_without_lambda_env_even_if_param_set(monkeypatch):


### PR DESCRIPTION
## Summary

- **chunk_size**: 300 → 175 — at 0.33 rps, chunk_size=300 gives 909s worst-case (exceeds the 900s Lambda timeout; 2023-06 was observed at 887s). New size gives ~200s safety margin.
- **details_rate_limit**: 0.33 → 0.25 rps — 175 × 4.0s = 700s per chunk ✓
- **reports_rate_limit**: 0.33 → 0.4 rps — 175 × 2.5s = 437s per chunk ✓ (SSM currently at 0.5; this change brings code default and SSM into sync at 0.4)
- **TournamentsFunction**: 256 MB → 192 MB (117 MB peak — pure async HTTP + text write)
- **SplitIdsFunction**: 256 MB → 128 MB (reads a text file, splits it, writes chunks)

More chunks per large month (12 vs 7 for a 2000-tournament month), with 3 rounds at max_concurrency=5 vs 2 rounds before. Per-round time drops enough that total wall-clock is only ~13% slower — well within the 2h EventBridge cadence.

## After merging and deploying

Update SSM to match new code defaults (SSM currently has `reports_rate_limit: 0.5` which overrides the 0.4 code default):

```bash
aws ssm put-parameter --name /fide-glicko/pipeline/config \
  --type String --overwrite \
  --value '{"chunk_size": 175, "details_rate_limit": 0.25, "reports_rate_limit": 0.4, "max_concurrency": 5}'
```

## Test plan

- [x] `uv run pytest -m "not online" -q` — 79 passed
- [ ] After deploy: invoke orchestrator; inspect next DetailsChunk execution — should complete in ~600–700s, not 880s+
- [ ] Confirm `chunk_size: 175` and `reports_rate_limit: 0.4` appear in execution input JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)